### PR TITLE
Change editor layout from vertical to horizontal

### DIFF
--- a/app/src/react-flow-visualization/store/layout.ts
+++ b/app/src/react-flow-visualization/store/layout.ts
@@ -9,7 +9,7 @@ const elk = new ELK()
 
 const layoutOptions = {
   "elk.algorithm": "layered",
-  "elk.direction": "DOWN",
+  "elk.direction": "RIGHT",
   "elk.layered.spacing.edgeNodeBetweenLayers": "40",
   "elk.spacing.nodeNode": "80",
   "elk.layered.nodePlacement.strategy": "SIMPLE",
@@ -21,7 +21,7 @@ function createTargetPort(id: string) {
   return {
     id,
     layoutOptions: {
-      side: "NORTH",
+      side: "WEST",
     },
   }
 }
@@ -30,7 +30,7 @@ function createSourcePort(id: string) {
   return {
     id,
     layoutOptions: {
-      side: "SOUTH",
+      side: "EAST",
     },
   }
 }


### PR DESCRIPTION
## Summary
- Changed React Flow editor layout from top-down to left-right orientation for improved clarity
- Updated ELK graph layout algorithm direction from DOWN to RIGHT
- Adjusted port positions to match horizontal flow (targets: WEST, sources: EAST)

## Test plan
- [ ] Verify nodes arrange horizontally from left to right
- [ ] Confirm connections flow from right side of source nodes to left side of target nodes
- [ ] Test with multiple connected and disconnected components
- [ ] Ensure automatic layout still works correctly after changes

🤖 Generated with [Claude Code](https://claude.ai/code)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Switched the React Flow editor from vertical (top-down) to horizontal (left-to-right) to improve readability. Updated ELK direction to RIGHT and port sides to EAST (sources) and WEST (targets) so edges run from the right of source nodes to the left of target nodes.

<!-- End of auto-generated description by cubic. -->

