### PR TITLE
fix(app): rename ingestions to evaluations and route to edit page

### DIFF
--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -55,13 +55,13 @@ export default function HomePage() {
           </Link>
 
           <Link
-            href="/ingestions"
+            href="/edit?mode=eval"
             className="group flex flex-col items-center p-8 transition-all duration-300 hover:translate-y-[-2px]"
           >
             <div className="w-16 h-16 mb-6 rounded-full bg-black/5 flex items-center justify-center group-hover:bg-black/10 transition-colors duration-300">
               <span className="text-2xl">⇪</span>
             </div>
-            <h3 className="text-xl font-light text-black mb-2">Ingestions</h3>
+            <h3 className="text-xl font-light text-black mb-2">Evaluations</h3>
             <p className="text-sm font-light text-black/50 text-center tracking-wide">
               Upload inputs and run workflows on them
             </p>


### PR DESCRIPTION
## Summary
- Update homepage link from "Ingestions" to "Evaluations"
- Route to `/edit?mode=eval` instead of broken `/ingestions` link
- Fix navigation issue where ingestions button didn't go anywhere

## Test plan
- [x] Verify TypeScript compilation passes
- [x] Verify linting passes  
- [x] Verify smoke tests pass
- [x] Check homepage displays "Evaluations" instead of "Ingestions"
- [x] Verify clicking Evaluations routes to `/edit?mode=eval`

🤖 Generated with [Claude Code](https://claude.ai/code)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Renamed “Ingestions” to “Evaluations” on the homepage and updated the link to route to /edit?mode=eval. This fixes the broken navigation and aligns the UI with the new terminology.

<!-- End of auto-generated description by cubic. -->

