### PR TITLE
feat: update database types with new DataSet table and relationships

### DIFF
--- a/packages/shared/src/types/database.types.ts
+++ b/packages/shared/src/types/database.types.ts
@@ -14,9 +14,40 @@ export type Database = {
   }
   public: {
     Tables: {
+      DataSet: {
+        Row: {
+          created_at: string
+          data_format: string | null
+          dataset_id: string
+          description: string | null
+          name: string
+          status: string | null
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          data_format?: string | null
+          dataset_id?: string
+          description?: string | null
+          name: string
+          status?: string | null
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          data_format?: string | null
+          dataset_id?: string
+          description?: string | null
+          name?: string
+          status?: string | null
+          updated_at?: string
+        }
+        Relationships: []
+      }
       DatasetRecord: {
         Row: {
           created_at: string
+          dataset_id: string
           dataset_record_id: string
           ground_truth: Json | null
           output_schema_json: Json | null
@@ -25,6 +56,7 @@ export type Database = {
         }
         Insert: {
           created_at?: string
+          dataset_id: string
           dataset_record_id?: string
           ground_truth?: Json | null
           output_schema_json?: Json | null
@@ -33,13 +65,22 @@ export type Database = {
         }
         Update: {
           created_at?: string
+          dataset_id?: string
           dataset_record_id?: string
           ground_truth?: Json | null
           output_schema_json?: Json | null
           rubric?: Json | null
           workflow_input?: string | null
         }
-        Relationships: []
+        Relationships: [
+          {
+            foreignKeyName: "DatasetRecord_dataset_id_fkey"
+            columns: ["dataset_id"]
+            isOneToOne: false
+            referencedRelation: "DataSet"
+            referencedColumns: ["dataset_id"]
+          },
+        ]
       }
       EvolutionRun: {
         Row: {


### PR DESCRIPTION
## Summary
- Added new DataSet table with dataset management fields (dataset_id, name, description, data_format, status)
- Added foreign key relationship from DatasetRecord to DataSet table via dataset_id
- Updated TypeScript types generated from latest database migration
- All type checks and unit tests passing

## Test plan
- [x] TypeScript compilation passes in all packages (app, core, runtime, shared)
- [x] All 207 unit tests pass in core module
- [x] Pre-commit hooks pass (type checking and smoke tests)
- [x] Database type generation script runs successfully

🤖 Generated with [Claude Code](https://claude.ai/code)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Introduce a new DataSet table and link DatasetRecord via dataset_id. Updates generated TypeScript database types to match the latest migration and enable type-safe dataset management.

- **New Features**
  - Add DataSet table types: dataset_id, name, description, data_format, status, created_at, updated_at.
  - Add dataset_id to DatasetRecord with a foreign key to DataSet.

- **Migration**
  - Apply the latest database migration and regenerate types.
  - Ensure dataset_id is provided when inserting DatasetRecord.

<!-- End of auto-generated description by cubic. -->

