### PR TITLE
feat: add Settings navigation and Clerk branding to sidebar

### DIFF
--- a/app/src/components/Sidebar.tsx
+++ b/app/src/components/Sidebar.tsx
@@ -9,6 +9,7 @@ import {
   BarChart2,
   Boxes,
   Dna,
+  Settings,
   Menu,
   X,
   ChevronLeft,
@@ -56,6 +57,12 @@ const sidebarItems: SidebarItem[] = [
     label: "Evolution",
     icon: Dna,
     description: "Evolution tracking",
+  },
+  {
+    href: "/settings",
+    label: "Settings",
+    icon: Settings,
+    description: "Application settings",
   },
 ]
 
@@ -214,6 +221,43 @@ export default function Sidebar() {
           isCollapsed && !isMobile && "text-center"
         )}>
           {isCollapsed && !isMobile ? "AAW" : "Agentic Workflows"}
+        </div>
+        
+        {/* Clerk branding */}
+        <div className={cn(
+          "flex items-center justify-center mt-3 pt-3 border-t border-sidebar-border/20 transition-all duration-300",
+          isCollapsed && !isMobile && "px-1"
+        )}>
+          <a 
+            href="https://clerk.com" 
+            target="_blank" 
+            rel="noopener noreferrer"
+            className="flex items-center gap-2 text-sidebar-foreground/40 hover:text-sidebar-foreground/60 transition-colors text-[10px] font-medium"
+            title="Powered by Clerk"
+          >
+            <svg 
+              width="16" 
+              height="16" 
+              viewBox="0 0 200 200" 
+              className={cn(
+                "transition-all duration-300",
+                isCollapsed && !isMobile && "w-4 h-4"
+              )}
+              aria-hidden="true"
+            >
+              <path 
+                fill="currentColor" 
+                d="M114 0H86v86h28c15.464 0 28 12.536 28 28s-12.536 28-28 28H86v58h28c47.128 0 86-38.872 86-86V86c0-47.128-38.872-86-86-86Z"
+              />
+              <path 
+                fill="currentColor" 
+                d="M86 200H58c-32.032 0-58-25.968-58-58v-28h28c15.464 0 28-12.536 28-28S43.464 58 28 58H0V30C0 13.432 13.432 0 30 0h28c15.464 0 28 12.536 28 28v172Z"
+              />
+            </svg>
+            {!isCollapsed || isMobile ? (
+              <span className="transition-all duration-300">Secured by Clerk</span>
+            ) : null}
+          </a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Add Settings navigation item to sidebar with Settings icon and proper routing to `/settings` page
- Add Clerk logo and "Secured by Clerk" branding to the sidebar footer 
- Implement responsive design that adapts when sidebar is collapsed/expanded

## Test plan
- [x] Verify Settings link appears in sidebar navigation
- [x] Test Settings link routes to `/settings` page correctly
- [x] Confirm Clerk logo displays at bottom of sidebar
- [x] Test responsive behavior when sidebar is collapsed/expanded
- [x] Verify accessibility features (proper aria-labels, tooltips)
- [x] Test mobile responsiveness

🤖 Generated with [Claude Code](https://claude.ai/code)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add a Settings link to the sidebar with the correct icon and routing to /settings. Also add “Secured by Clerk” branding in the footer, and update the sidebar to be responsive and accessible in collapsed and mobile states.

<!-- End of auto-generated description by cubic. -->

