### PR TITLE
fix: improve sidebar UI and graph layout

### DIFF
--- a/app/src/components/Sidebar.tsx
+++ b/app/src/components/Sidebar.tsx
@@ -164,7 +164,7 @@ export default function Sidebar() {
                     <TooltipContent 
                       side="right" 
                       sideOffset={8}
-                      className="bg-background/95 backdrop-blur-sm border-border text-foreground shadow-lg"
+                      className="bg-popover text-popover-foreground border border-border shadow-md"
                     >
                       <p className="font-medium">{item.label}</p>
                       {item.description && (

--- a/app/src/react-flow-visualization/components/layouts/sidebar-layout/app-sidebar.tsx
+++ b/app/src/react-flow-visualization/components/layouts/sidebar-layout/app-sidebar.tsx
@@ -156,7 +156,7 @@ function DraggableItem(props: NodeConfig) {
           <Plus className="size-4" />
         </span>
       )}
-      <SidebarMenuButton className="bg-card cursor-grab active:cursor-grabbing">
+      <SidebarMenuButton className="bg-card cursor-grab active:cursor-grabbing cursor-pointer">
         {IconComponent ? <IconComponent aria-label={props?.icon} /> : null}
         <span>{props.displayName}</span>
         <GripVertical className="ml-auto" />

--- a/app/src/react-flow-visualization/store/layout.ts
+++ b/app/src/react-flow-visualization/store/layout.ts
@@ -9,7 +9,7 @@ const elk = new ELK()
 
 const layoutOptions = {
   "elk.algorithm": "layered",
-  "elk.direction": "RIGHT",
+  "elk.direction": "RIGHT", // Left-to-right flow direction
   "elk.layered.spacing.edgeNodeBetweenLayers": "40",
   "elk.spacing.nodeNode": "80",
   "elk.layered.nodePlacement.strategy": "SIMPLE",
@@ -21,7 +21,7 @@ function createTargetPort(id: string) {
   return {
     id,
     layoutOptions: {
-      side: "WEST",
+      side: "WEST", // Input ports on the left side for left-to-right flow
     },
   }
 }
@@ -30,7 +30,7 @@ function createSourcePort(id: string) {
   return {
     id,
     layoutOptions: {
-      side: "EAST",
+      side: "EAST", // Output ports on the right side for left-to-right flow
     },
   }
 }


### PR DESCRIPTION
## Summary
- Fix sidebar tooltip dark background styling issue
- Add missing cursor-pointer to sidebar draggable items
- Document and verify graph layout for proper left-to-right flow direction

## Test plan
- [ ] Verify sidebar tooltips no longer have dark/black background
- [ ] Check that sidebar draggable items show pointer cursor on hover
- [ ] Confirm graph editor flows left-to-right as expected

🤖 Generated with [Claude Code](https://claude.ai/code)