### PR TITLE
fix: prevent esbuild service conflicts during install

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -10,8 +10,8 @@
         "dist"
     ],
     "scripts": {
-        "build": "bun x tsup",
-        "dev": "bun x tsup --watch",
+        "build": "tsup",
+        "dev": "tsup --watch",
         "clean": "rimraf dist",
         "prebuild": "rimraf dist && rm -f tsconfig.tsbuildinfo",
         "generate": "npx supabase@latest gen types typescript --project-id qnvprftdorualkdyogka --schema public > src/types/database.types.ts",


### PR DESCRIPTION
## Summary
- Fixed esbuild service conflicts that caused install failures when multiple projects have running esbuild services
- Changed `bun x tsup` to `tsup` in packages/shared to use local node_modules instead of global resolution

## Root Cause
The error "The service was stopped" occurred because `bun x tsup` could resolve to esbuild installations from other workspaces, causing service conflicts when multiple projects had active esbuild processes.

## Solution
Use `tsup` directly instead of `bun x tsup` to ensure the locally installed version is used, preventing cross-workspace esbuild service conflicts.

## Test Plan
- [x] Fresh install works correctly
- [x] Type checking passes
- [x] Smoke tests pass
- [x] Build process unchanged (same output)

🤖 Generated with [Claude Code](https://claude.ai/code)