### PR TITLE
fix: update build scripts for consistency and clarity

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "postinstall": "bun run build:shared",
     "web": "cd app && bun run dev",
     "build:shared": "cd packages/shared && bun run build",
-    "build:app": "bun -C app run build",
+    "build:app": "cd app && bun run build",
     "build": "bun run build:shared && bun run build:app",
     "test:smoke": "bunx vitest run tests/e2e-essential/smoke --config tests/e2e-essential/vitest.config.ts",
     "test:gate": "bunx vitest run tests/e2e-essential --config tests/e2e-essential/vitest.config.ts",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -10,7 +10,7 @@
         "dist"
     ],
     "scripts": {
-        "build": "tsup",
+        "build": "tsup --silent",
         "dev": "tsup --watch",
         "clean": "rimraf dist",
         "prebuild": "rimraf dist && rm -f tsconfig.tsbuildinfo",


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Align build scripts for consistency and quieter output. build:app now uses cd app && bun run build, and the shared package build runs tsup --silent.

<!-- End of auto-generated description by cubic. -->

