### PR TITLE
feat(auth): use authenticated supabase client for WorkflowInvocation queries

### DIFF
--- a/apps/web/src/app/api/trace/[wf_inv_id]/node-invocations/route.ts
+++ b/apps/web/src/app/api/trace/[wf_inv_id]/node-invocations/route.ts
@@ -1,5 +1,5 @@
 import { requireAuth } from "@/lib/api-auth"
-import { supabase } from "@/lib/supabase"
+import { createClient } from "@/lib/supabase/server"
 import { nodeInvocations } from "@/trace-visualization/db/Workflow/nodeInvocations"
 import { NextResponse } from "next/server"
 
@@ -8,10 +8,12 @@ export async function GET(_request: Request, { params }: { params: Promise<{ wf_
   const authResult = await requireAuth()
   if (authResult instanceof NextResponse) return authResult
 
+  const supabase = await createClient()
+
   try {
     const { wf_inv_id } = await params
 
-    // Verify the workflow invocation exists
+    // Verify the workflow invocation exists and user has access (RLS will enforce)
     const { data: exists, error: existsError } = await supabase
       .from("WorkflowInvocation")
       .select("wf_invocation_id")

--- a/apps/web/src/app/api/workflow/invocations/route.ts
+++ b/apps/web/src/app/api/workflow/invocations/route.ts
@@ -1,5 +1,5 @@
 import { requireAuth } from "@/lib/api-auth"
-import { supabase } from "@/lib/supabase"
+import { createClient } from "@/lib/supabase/server"
 import { type NextRequest, NextResponse } from "next/server"
 
 export const dynamic = "force-dynamic"
@@ -52,6 +52,7 @@ export async function GET(request: NextRequest) {
   const authResult = await requireAuth()
   if (authResult instanceof NextResponse) return authResult
 
+  const supabase = await createClient()
   const searchParams = request.nextUrl.searchParams
   const page = Number.parseInt(searchParams.get("page") || "1", 10)
   const pageSize = Number.parseInt(searchParams.get("pageSize") || "20", 10)
@@ -173,6 +174,8 @@ export async function DELETE(request: NextRequest) {
   // Require authentication
   const authResult = await requireAuth()
   if (authResult instanceof NextResponse) return authResult
+
+  const supabase = await createClient()
 
   try {
     const body = await request.json()

--- a/apps/web/src/trace-visualization/db/Workflow/basicWorkflow.ts
+++ b/apps/web/src/trace-visualization/db/Workflow/basicWorkflow.ts
@@ -1,5 +1,5 @@
 "use server"
-import { supabase } from "@/lib/supabase"
+import { createClient } from "@/lib/supabase/server"
 import type { Tables } from "@lucky/shared/client"
 import { cache } from "react"
 
@@ -10,6 +10,7 @@ export interface BasicWorkflowResult {
 }
 
 export const basicWorkflow = cache(async (workflowInvocationId: string): Promise<BasicWorkflowResult | null> => {
+  const supabase = await createClient()
   const { data, error } = await supabase
     .from("WorkflowInvocation")
     .select(

--- a/apps/web/src/trace-visualization/db/Workflow/fullWorkflow.ts
+++ b/apps/web/src/trace-visualization/db/Workflow/fullWorkflow.ts
@@ -1,5 +1,5 @@
 "use server"
-import { supabase } from "@/lib/supabase"
+import { createClient } from "@/lib/supabase/server"
 import { safeJSON } from "@/trace-visualization/db/Workflow/utils"
 import type { AgentStep, AgentSteps } from "@lucky/core/messages/pipeline/AgentStep.types"
 import type { NodeMemory } from "@lucky/core/utils/memory/memorySchema"
@@ -39,6 +39,7 @@ export interface FullWorkflowResult {
 }
 
 export const fullWorkflow = cache(async (workflowInvocationId: string): Promise<FullWorkflowResult | null> => {
+  const supabase = await createClient()
   const { data, error } = await supabase
     .from("WorkflowInvocation")
     .select(

--- a/apps/web/src/trace-visualization/db/Workflow/nodeInvocations.ts
+++ b/apps/web/src/trace-visualization/db/Workflow/nodeInvocations.ts
@@ -1,6 +1,6 @@
 "use server"
 
-import { supabase } from "@/lib/supabase"
+import { createClient } from "@/lib/supabase/server"
 import { cache } from "react"
 import {
   type MessageMetadata,
@@ -22,6 +22,7 @@ export interface NodeInvocationsResult {
  * Only fetches essential Message fields to avoid timeouts on large payloads.
  */
 export const nodeInvocations = cache(async (workflowInvocationId: string): Promise<NodeInvocationsResult> => {
+  const supabase = await createClient()
   const { data: invocations, error } = await supabase
     .from("NodeInvocation")
     .select(

--- a/apps/web/src/trace-visualization/db/Workflow/retrieveWorkflow.ts
+++ b/apps/web/src/trace-visualization/db/Workflow/retrieveWorkflow.ts
@@ -1,10 +1,11 @@
 "use server"
-import { supabase } from "@/lib/supabase"
+import { createClient } from "@/lib/supabase/server"
 import { genShortId } from "@lucky/core/utils/common/utils"
 import { lgg } from "@lucky/core/utils/logging/Logger"
 import type { Tables, TablesInsert, TablesUpdate } from "@lucky/shared/client"
 
 export const retrieveWorkflowInvocation = async (invocationId: string): Promise<Tables<"WorkflowInvocation">> => {
+  const supabase = await createClient()
   const { data, error: WFInvocationError } = await supabase
     .from("WorkflowInvocation")
     .select("*")
@@ -27,6 +28,7 @@ export const retrieveWorkflowInvocation = async (invocationId: string): Promise<
 }
 
 export const retrieveWorkflowVersion = async (workflowVersionId: string): Promise<Tables<"WorkflowVersion">> => {
+  const supabase = await createClient()
   const { data, error: WFVersionError } = await supabase
     .from("WorkflowVersion")
     .select("*")
@@ -41,6 +43,7 @@ export const retrieveWorkflowVersion = async (workflowVersionId: string): Promis
 }
 
 export const ensureWorkflowExists = async (description: string, workflowId: string): Promise<void> => {
+  const supabase = await createClient()
   const workflowInsertable: TablesInsert<"Workflow"> = {
     wf_id: workflowId,
     description,
@@ -61,6 +64,7 @@ export const saveWorkflowVersion = async (data: {
   iterationBudget?: number
   timeBudgetSeconds?: number
 }): Promise<Tables<"WorkflowVersion">> => {
+  const supabase = await createClient()
   const { dsl, commitMessage, workflowId, parentId, iterationBudget = 50, timeBudgetSeconds = 3600 } = data
 
   const insertData: TablesInsert<"WorkflowVersion"> = {
@@ -113,6 +117,7 @@ export const retrieveWorkflowInvocations = async (
   filters?: WorkflowInvocationFilters,
   sort?: WorkflowInvocationSortOptions,
 ): Promise<WorkflowInvocationsResponse> => {
+  const supabase = await createClient()
   // First, build the base query with count
   let query = supabase.from("WorkflowInvocation").select("*", { count: "exact" })
 
@@ -242,6 +247,7 @@ export const retrieveWorkflowInvocations = async (
 }
 
 export const retrieveLatestWorkflowVersions = async (limit?: number): Promise<Tables<"WorkflowVersion">[]> => {
+  const supabase = await createClient()
   let query = supabase.from("WorkflowVersion").select("*").order("created_at", { ascending: false })
 
   if (limit) {
@@ -258,6 +264,7 @@ export const retrieveLatestWorkflowVersions = async (limit?: number): Promise<Ta
 }
 
 export const deleteWorkflowInvocations = async (invocationIds: string[]): Promise<number> => {
+  const supabase = await createClient()
   const { error } = await supabase.from("WorkflowInvocation").delete().in("wf_invocation_id", invocationIds)
 
   if (error) throw error
@@ -271,6 +278,7 @@ export const deleteWorkflowInvocations = async (invocationIds: string[]): Promis
  * This more aggressive cleanup prevents false "running" status display
  */
 export const cleanupStaleWorkflowInvocations = async (): Promise<number> => {
+  const supabase = await createClient()
   const staleThresholdMinutes = 10 // Reduced from 2 hours to 10 minutes
   const staleThresholdMs = staleThresholdMinutes * 60 * 1000
   const cutoffTime = new Date(Date.now() - staleThresholdMs).toISOString()

--- a/apps/web/src/trace-visualization/db/Workflow/updateWorkflowInvocation.ts
+++ b/apps/web/src/trace-visualization/db/Workflow/updateWorkflowInvocation.ts
@@ -1,4 +1,4 @@
-import { supabase } from "@/lib/supabase"
+import { createClient } from "@/lib/supabase/server"
 import { lgg } from "@lucky/core/utils/logging/Logger"
 
 export interface InvocationScores {
@@ -8,6 +8,7 @@ export interface InvocationScores {
 
 export async function updateWorkflowInvocationScores(invocationId: string, scores: InvocationScores): Promise<void> {
   try {
+    const supabase = await createClient()
     const roundedAccuracy = Math.round(scores.accuracy)
     const roundedFitness = Math.round(scores.fitness)
     const { error } = await supabase


### PR DESCRIPTION
## Summary

Updates frontend to use authenticated Supabase server client instead of unauthenticated anon client. This ensures RLS policies on `WorkflowInvocation` can properly enforce data ownership at the database level.

## Changes

**API Routes:**
- `apps/web/src/app/api/workflow/invocations/route.ts` - GET and DELETE endpoints now use authenticated client
- `apps/web/src/app/api/trace/[wf_inv_id]/node-invocations/route.ts` - GET endpoint uses authenticated client

**Server Actions:**
- `apps/web/src/trace-visualization/db/Workflow/basicWorkflow.ts` - Updated to use authenticated client
- `apps/web/src/trace-visualization/db/Workflow/retrieveWorkflow.ts` - All functions now use authenticated client
- `apps/web/src/trace-visualization/db/Workflow/updateWorkflowInvocation.ts` - Updated to use authenticated client
- `apps/web/src/trace-visualization/db/Workflow/fullWorkflow.ts` - Updated to use authenticated client
- `apps/web/src/trace-visualization/db/Workflow/nodeInvocations.ts` - Updated to use authenticated client

## Technical Details

### Before
- Used `@/lib/supabase` client (anon key, no auth context)
- RLS policies couldn't resolve `iam.current_user_id()`
- All queries would fail with RLS enabled

### After
- Uses `@/lib/supabase/server` client (`createClient()`)
- Passes JWT token from Clerk auth via cookies
- RLS policies can now resolve user context correctly
- Ownership enforced via FK chain: `WorkflowInvocation → WorkflowVersion → Workflow → user_id`

## Security

- ✅ Enables row-level security enforcement at database level
- ✅ Users can only access their own workflow invocations
- ✅ Ownership verified through existing foreign key relationships (normalized approach)
- ✅ Security enforced at DB layer, cannot be bypassed by application code

## Testing

- ✅ TypeScript passes (`bun run tsc`)
- ✅ Build succeeds (`bun run build`)
- ✅ Pre-commit hooks pass (lint-staged, smoke tests)

## Context

This PR implements the frontend changes needed to support RLS policies that were added to the `WorkflowInvocation` table. The RLS policies use the existing FK chain to determine ownership without requiring denormalization (no `user_id` column added to `WorkflowInvocation`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)