### PR TITLE
fix(web): resolve workflow version 500 error and models module resolution

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next"
 
 const nextConfig: NextConfig = {
-  transpilePackages: ["@lucky/shared", "@lucky/tools"],
+  transpilePackages: ["@lucky/shared", "@lucky/tools", "@lucky/models"],
   outputFileTracingExcludes: {
     "/api/*": [".next/**"],
   },

--- a/apps/web/src/app/api/workflow/version/[wf_version_id]/route.ts
+++ b/apps/web/src/app/api/workflow/version/[wf_version_id]/route.ts
@@ -1,5 +1,5 @@
 import { requireAuth } from "@/lib/api-auth"
-import { createClient } from "@/lib/supabase/server"
+import { createRLSClient } from "@/lib/supabase/server-rls"
 import { type NextRequest, NextResponse } from "next/server"
 
 export const dynamic = "force-dynamic"
@@ -9,7 +9,7 @@ export async function GET(_req: NextRequest, { params }: { params: Promise<{ wf_
   const authResult = await requireAuth()
   if (authResult instanceof NextResponse) return authResult
 
-  const supabase = await createClient()
+  const supabase = await createRLSClient()
   const { wf_version_id } = await params
 
   try {

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -33,6 +33,8 @@
       "@lucky/examples/*": ["../examples/*"],
       "@lucky/experiments": ["../../packages/experiments/src"],
       "@lucky/experiments/*": ["../../packages/experiments/src/*"],
+      "@lucky/models": ["../../packages/models/src"],
+      "@lucky/models/*": ["../../packages/models/src/*"],
       "@lucky/shared": ["../../packages/shared/src"],
       "@lucky/shared/*": ["../../packages/shared/src/*"],
       "@lucky/tools": ["../../packages/tools/src"],


### PR DESCRIPTION
## Summary
- Fix workflow version API route to use `createRLSClient()` for proper Clerk session authentication with Supabase RLS
- Add `@lucky/models` package configuration to resolve module import errors

## Changes
1. **API Route Fix** (`apps/web/src/app/api/workflow/version/[wf_version_id]/route.ts`):
   - Changed from `createClient()` to `createRLSClient()` to properly pass Clerk session token to Supabase
   - This ensures RLS policies can authenticate the user correctly

2. **Module Resolution** (`apps/web/tsconfig.json`, `apps/web/next.config.ts`):
   - Added `@lucky/models` path mappings to `tsconfig.json`
   - Added `@lucky/models` to `transpilePackages` in `next.config.ts`
   - Built `@lucky/models` package to generate `dist/` output

## Root Cause
The workflow version endpoint was using `createClient()` which doesn't pass the Clerk session token, causing Supabase RLS to reject authenticated queries with a 500 error. Additionally, the `@lucky/models` package wasn't configured in the web app's build pipeline.

## Test Plan
- [x] TypeScript type checking passes
- [x] Core unit tests pass  
- [x] Smoke tests pass
- [x] Gate tests pass
- [x] Dev server starts without module resolution errors
- [x] Workflow version API endpoint accessible (requires authentication)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fix 500 errors on the workflow version API by switching to the Supabase RLS client and forwarding the Clerk session. Also resolve @lucky/models imports with path aliases and Next transpile configuration.

- **Bug Fixes**
  - Use createRLSClient in the workflow version route to pass the Clerk token to Supabase, so RLS authenticates correctly.
  - Add @lucky/models path aliases in tsconfig and include it in transpilePackages to fix module import errors.

<!-- End of auto-generated description by cubic. -->

