### PR TITLE
feat(db): update database types and improve type generation

### DIFF
--- a/apps/web/src/trace-visualization/db/Evolution/retrieveEvolution.ts
+++ b/apps/web/src/trace-visualization/db/Evolution/retrieveEvolution.ts
@@ -106,6 +106,7 @@ const performComplexQuery = async (runId: string): Promise<GenerationWithData[]>
       end_time,
       run_id,
       best_workflow_version_id,
+      clerk_id,
       workflow_invocations:WorkflowInvocation!fk_wfi_generation (
         wf_invocation_id,
         wf_version_id,
@@ -156,6 +157,7 @@ const performComplexQuery = async (runId: string): Promise<GenerationWithData[]>
           end_time: generation.end_time,
           run_id: generation.run_id,
           best_workflow_version_id: generation.best_workflow_version_id,
+          clerk_id: generation.clerk_id,
         },
         versions: generationVersions,
         invocations: generation.workflow_invocations || [],

--- a/packages/shared/scripts/generate-db-types.ts
+++ b/packages/shared/scripts/generate-db-types.ts
@@ -3,21 +3,16 @@ import { existsSync, mkdirSync, writeFileSync } from "node:fs"
 import { dirname, resolve } from "node:path"
 
 const env = process.env
-const token = env.SUPABASE_ACCESS_TOKEN || ""
 const isCI = env.CI === "1" || env.CI === "true"
 const isVercel = env.VERCEL === "1" || env.VERCEL === "true"
+const skipGeneration = env.SKIP_DB_TYPES_GENERATION === "1" || env.SKIP_DB_TYPES_GENERATION === "true"
 
 const outPath = resolve(import.meta.dir, "../src/types/database.types.ts")
 
 async function main() {
-  if (!token) {
-    // No token: skip generation gracefully, rely on committed types.
-    console.log("Skipping Supabase types generation: SUPABASE_ACCESS_TOKEN not set")
-    if (isCI || isVercel) {
-      console.log("Detected CI/VERCEL. Using committed types if present…")
-    } else {
-      console.log("Tip: set SUPABASE_ACCESS_TOKEN locally to refresh generated types.")
-    }
+  // Skip generation in CI/Vercel builds to use committed types
+  if (skipGeneration || isCI || isVercel) {
+    console.log("Using committed database types (Vercel/CI build)")
     return
   }
 
@@ -56,7 +51,7 @@ async function main() {
 }
 
 main().catch(err => {
-  // Do not fail CI if generation was optional; but since we only got here with a token, surfacing error is useful.
-  console.error(err)
+  console.error("Failed to generate database types:", err)
+  console.error("To skip generation and use committed types, set SKIP_DB_TYPES_GENERATION=1")
   process.exit(1)
 })

--- a/packages/shared/src/types/database.types.ts
+++ b/packages/shared/src/types/database.types.ts
@@ -8,6 +8,60 @@ export type Database = {
   }
   iam: {
     Tables: {
+      org_memberships: {
+        Row: {
+          clerk_id: string
+          created_at: string | null
+          org_id: string
+          role: string
+        }
+        Insert: {
+          clerk_id: string
+          created_at?: string | null
+          org_id: string
+          role?: string
+        }
+        Update: {
+          clerk_id?: string
+          created_at?: string | null
+          org_id?: string
+          role?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "org_memberships_clerk_id_fkey"
+            columns: ["clerk_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["clerk_id"]
+          },
+          {
+            foreignKeyName: "org_memberships_org_id_fkey"
+            columns: ["org_id"]
+            isOneToOne: false
+            referencedRelation: "orgs"
+            referencedColumns: ["org_id"]
+          },
+        ]
+      }
+      orgs: {
+        Row: {
+          created_at: string | null
+          name: string
+          org_id: string
+        }
+        Insert: {
+          created_at?: string | null
+          name: string
+          org_id?: string
+        }
+        Update: {
+          created_at?: string | null
+          name?: string
+          org_id?: string
+        }
+        Relationships: []
+      }
       users: {
         Row: {
           avatar_url: string | null
@@ -18,7 +72,6 @@ export type Database = {
           metadata: Json
           status: Database["iam"]["Enums"]["user_status"]
           updated_at: string
-          user_id: string
         }
         Insert: {
           avatar_url?: string | null
@@ -29,7 +82,6 @@ export type Database = {
           metadata?: Json
           status?: Database["iam"]["Enums"]["user_status"]
           updated_at?: string
-          user_id?: string
         }
         Update: {
           avatar_url?: string | null
@@ -40,7 +92,6 @@ export type Database = {
           metadata?: Json
           status?: Database["iam"]["Enums"]["user_status"]
           updated_at?: string
-          user_id?: string
         }
         Relationships: []
       }
@@ -49,7 +100,18 @@ export type Database = {
       [_ in never]: never
     }
     Functions: {
-      [_ in never]: never
+      current_clerk_id: {
+        Args: Record<PropertyKey, never>
+        Returns: string
+      }
+      is_org_admin: {
+        Args: { p_org_id: string }
+        Returns: boolean
+      }
+      is_org_member: {
+        Args: { p_org_id: string }
+        Returns: boolean
+      }
     }
     Enums: {
       user_status: "active" | "disabled" | "invited"
@@ -469,35 +531,27 @@ export type Database = {
       }
       Workflow: {
         Row: {
+          clerk_id: string | null
           created_at: string
           description: string
           updated_at: string
-          user_id: string | null
           wf_id: string
         }
         Insert: {
+          clerk_id?: string | null
           created_at?: string
           description: string
           updated_at?: string
-          user_id?: string | null
           wf_id?: string
         }
         Update: {
+          clerk_id?: string | null
           created_at?: string
           description?: string
           updated_at?: string
-          user_id?: string | null
           wf_id?: string
         }
-        Relationships: [
-          {
-            foreignKeyName: "Workflow_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "User"
-            referencedColumns: ["user_id"]
-          },
-        ]
+        Relationships: []
       }
       WorkflowInvocation: {
         Row: {
@@ -728,24 +782,7 @@ export type Database = {
       }
     }
     Views: {
-      User: {
-        Row: {
-          clerk_id: string | null
-          created_at: string | null
-          user_id: string | null
-        }
-        Insert: {
-          clerk_id?: string | null
-          created_at?: string | null
-          user_id?: string | null
-        }
-        Update: {
-          clerk_id?: string | null
-          created_at?: string | null
-          user_id?: string | null
-        }
-        Relationships: []
-      }
+      [_ in never]: never
     }
     Functions: {
       gen_prefixed_id: {
@@ -753,6 +790,14 @@ export type Database = {
         Returns: string
       }
       gen_short_id: {
+        Args: Record<PropertyKey, never>
+        Returns: string
+      }
+      require_authenticated: {
+        Args: Record<PropertyKey, never>
+        Returns: undefined
+      }
+      sub: {
         Args: Record<PropertyKey, never>
         Returns: string
       }

--- a/packages/shared/src/types/database.types.ts
+++ b/packages/shared/src/types/database.types.ts
@@ -124,6 +124,7 @@ export type Database = {
     Tables: {
       DataSet: {
         Row: {
+          clerk_id: string
           created_at: string
           data_format: string | null
           dataset_id: string
@@ -133,6 +134,7 @@ export type Database = {
           updated_at: string
         }
         Insert: {
+          clerk_id?: string
           created_at?: string
           data_format?: string | null
           dataset_id?: string
@@ -142,6 +144,7 @@ export type Database = {
           updated_at?: string
         }
         Update: {
+          clerk_id?: string
           created_at?: string
           data_format?: string | null
           dataset_id?: string
@@ -237,6 +240,7 @@ export type Database = {
       }
       Evaluator: {
         Row: {
+          clerk_id: string
           config: Json | null
           created_at: string
           evaluator_id: string
@@ -244,6 +248,7 @@ export type Database = {
           rubric: Json | null
         }
         Insert: {
+          clerk_id?: string
           config?: Json | null
           created_at?: string
           evaluator_id?: string
@@ -251,6 +256,7 @@ export type Database = {
           rubric?: Json | null
         }
         Update: {
+          clerk_id?: string
           config?: Json | null
           created_at?: string
           evaluator_id?: string
@@ -261,6 +267,7 @@ export type Database = {
       }
       EvolutionRun: {
         Row: {
+          clerk_id: string | null
           config: Json
           end_time: string | null
           evolution_type: string | null
@@ -271,6 +278,7 @@ export type Database = {
           status: Database["public"]["Enums"]["EvolutionRunStatus"]
         }
         Insert: {
+          clerk_id?: string | null
           config: Json
           end_time?: string | null
           evolution_type?: string | null
@@ -281,6 +289,7 @@ export type Database = {
           status?: Database["public"]["Enums"]["EvolutionRunStatus"]
         }
         Update: {
+          clerk_id?: string | null
           config?: Json
           end_time?: string | null
           evolution_type?: string | null
@@ -295,6 +304,7 @@ export type Database = {
       Generation: {
         Row: {
           best_workflow_version_id: string | null
+          clerk_id: string | null
           comment: string | null
           end_time: string | null
           feedback: string | null
@@ -305,6 +315,7 @@ export type Database = {
         }
         Insert: {
           best_workflow_version_id?: string | null
+          clerk_id?: string | null
           comment?: string | null
           end_time?: string | null
           feedback?: string | null
@@ -315,6 +326,7 @@ export type Database = {
         }
         Update: {
           best_workflow_version_id?: string | null
+          clerk_id?: string | null
           comment?: string | null
           end_time?: string | null
           feedback?: string | null
@@ -679,7 +691,7 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: "WorkflowInvocationEvaluation_wf_inv_id_fkey"
+            foreignKeyName: "WorkflowInvocationEval_wf_inv_id_fkey"
             columns: ["wf_inv_id"]
             isOneToOne: false
             referencedRelation: "WorkflowInvocation"
@@ -785,6 +797,10 @@ export type Database = {
       [_ in never]: never
     }
     Functions: {
+      current_clerk_id: {
+        Args: Record<PropertyKey, never>
+        Returns: string
+      }
       gen_prefixed_id: {
         Args: { p_prefix: string }
         Returns: string
@@ -792,6 +808,18 @@ export type Database = {
       gen_short_id: {
         Args: Record<PropertyKey, never>
         Returns: string
+      }
+      owns_workflow: {
+        Args: { p_workflow_id: string }
+        Returns: boolean
+      }
+      owns_workflow_invocation: {
+        Args: { p_wf_invocation_id: string }
+        Returns: boolean
+      }
+      owns_workflow_version: {
+        Args: { p_wf_version_id: string }
+        Returns: boolean
       }
       require_authenticated: {
         Args: Record<PropertyKey, never>


### PR DESCRIPTION
## Summary
- Add `org_memberships` and `orgs` tables to support multi-tenancy
- Add `clerk_id` to DataSet, Evaluator, EvolutionRun, and Generation tables  
- Remove `user_id` field from users table (using `clerk_id` instead)
- Simplify type generation script to skip in CI/Vercel builds
- Add `SKIP_DB_TYPES_GENERATION` flag for build flexibility
- Fix GenerationWithData to include `clerk_id` field in query and mapping

## Changes
### Database Schema
- Added new IAM tables for organization management
- Migrated from `user_id` to `clerk_id` for user identification
- Added `clerk_id` to multiple tables for user ownership tracking

### Type Generation
- Updated generation script to use committed types in CI/Vercel
- Removed hard dependency on `SUPABASE_ACCESS_TOKEN`
- Added explicit skip flag for more control

### Bug Fixes
- Fixed missing `clerk_id` field in evolution trace visualization queries

## Test plan
- [x] TypeScript compilation passes
- [x] Smoke tests pass
- [x] Gate tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added org and membership tables for multi-tenancy and switched identity fields to clerk_id across the schema and types. Streamlined DB type generation to use committed types in CI/Vercel and fixed Evolution trace to include clerk_id.

- **New Features**
  - Added orgs and org_memberships tables.
  - Adopted clerk_id across DataSet, Evaluator, EvolutionRun, Generation, and Workflow.
  - Added IAM functions: current_clerk_id, is_org_admin, is_org_member.
  - Introduced SKIP_DB_TYPES_GENERATION to skip type generation; CI/Vercel builds use committed types.

- **Bug Fixes**
  - Included clerk_id in Evolution trace query and mapping.

<!-- End of auto-generated description by cubic. -->

