### PR TITLE
feat(web): add feedback button to sidebar

### DIFF
--- a/apps/web/src/app/components/aside/feedback-button.tsx
+++ b/apps/web/src/app/components/aside/feedback-button.tsx
@@ -1,0 +1,47 @@
+"use client"
+
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
+import { MessageSquare } from "lucide-react"
+import { useEffect, useState } from "react"
+import { GeneralFeedbackDialog } from "./general-feedback-dialog"
+
+export function FeedbackButton() {
+  const [isDialogOpen, setIsDialogOpen] = useState(false)
+
+  // Handle global keyboard shortcut ⌘⇧F
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key === "F") {
+        e.preventDefault()
+        setIsDialogOpen(true)
+      }
+    }
+
+    window.addEventListener("keydown", handleKeyDown)
+    return () => window.removeEventListener("keydown", handleKeyDown)
+  }, [])
+
+  return (
+    <>
+      <div className="relative h-[32px] mb-2">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              onClick={() => setIsDialogOpen(true)}
+              className="fixed left-[19px] w-[32px] h-[32px] flex items-center justify-center text-sidebar-foreground/70 hover:text-sidebar-primary transition-colors duration-200 rounded border border-[#DCDAD2] dark:border-[#2C2C2C] hover:bg-sidebar-accent"
+              aria-label="Send feedback"
+            >
+              <MessageSquare className="w-4 h-4" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="right" sideOffset={10}>
+            Send feedback ⌘⇧F
+          </TooltipContent>
+        </Tooltip>
+      </div>
+
+      <GeneralFeedbackDialog open={isDialogOpen} onOpenChange={setIsDialogOpen} />
+    </>
+  )
+}

--- a/apps/web/src/app/components/aside/general-feedback-dialog.tsx
+++ b/apps/web/src/app/components/aside/general-feedback-dialog.tsx
@@ -1,0 +1,96 @@
+"use client"
+
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/react-flow-visualization/components/ui/dialog"
+import { Textarea } from "@/react-flow-visualization/components/ui/textarea"
+import { Paperclip } from "lucide-react"
+import { useEffect, useState } from "react"
+import { toast } from "sonner"
+
+type GeneralFeedbackDialogProps = {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function GeneralFeedbackDialog({ open, onOpenChange }: GeneralFeedbackDialogProps) {
+  const [feedbackText, setFeedbackText] = useState("")
+
+  // Handle keyboard shortcut ⌘↵ for submission
+  useEffect(() => {
+    if (!open) return
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+        e.preventDefault()
+        handleFeedbackSubmit()
+      }
+    }
+
+    window.addEventListener("keydown", handleKeyDown)
+    return () => window.removeEventListener("keydown", handleKeyDown)
+  }, [open, feedbackText])
+
+  const handleFeedbackSubmit = () => {
+    if (!feedbackText.trim()) {
+      toast.error("Please enter your feedback")
+      return
+    }
+
+    // TODO: Implement actual feedback submission API
+    console.log("Feedback submitted:", feedbackText)
+
+    // Reset form and close dialog
+    setFeedbackText("")
+    onOpenChange(false)
+
+    // Show success toast
+    toast.success("Feedback submitted successfully!")
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="w-[90vw] max-w-[600px]">
+        <DialogHeader>
+          <DialogTitle className="text-2xl">Feedback</DialogTitle>
+          <DialogDescription className="text-sm text-muted-foreground pt-2">
+            We read every message. A real human will respond. You can also reach us at hello@goalive.nl
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-4">
+          <Textarea
+            placeholder="Tell us about your experience, bugs you've found, or features you'd like to see..."
+            value={feedbackText}
+            onChange={e => setFeedbackText(e.target.value)}
+            className="min-h-[200px] resize-none"
+          />
+
+          <div className="flex items-center justify-between">
+            <Button
+              variant="ghost"
+              size="sm"
+              className="text-muted-foreground hover:text-foreground"
+              onClick={() => {
+                // TODO: Implement image attachment functionality
+                toast.info("Image attachment coming soon!")
+              }}
+            >
+              <Paperclip className="w-4 h-4 mr-2" />
+              Attach images
+            </Button>
+
+            <Button onClick={handleFeedbackSubmit} disabled={!feedbackText.trim()}>
+              Send Feedback ⌘↵
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/web/src/app/components/aside/integrated-aside.tsx
+++ b/apps/web/src/app/components/aside/integrated-aside.tsx
@@ -7,6 +7,7 @@ import Link from "next/link"
 import { usePathname } from "next/navigation"
 import type React from "react"
 import { useState } from "react"
+import { FeedbackButton } from "./feedback-button"
 import { UserProfile } from "./user-profile"
 
 // Navigation items with submenu information
@@ -299,6 +300,9 @@ export function IntegratedAside() {
           </nav>
         </div>
       </div>
+
+      {/* Feedback Button */}
+      <FeedbackButton />
 
       {/* User Profile */}
       <UserProfile initials="AW" />


### PR DESCRIPTION
## Summary

Add user feedback collection UI to the integrated sidebar with keyboard shortcuts and a clean dialog interface.

## Changes

### New Components
- **FeedbackButton** (`feedback-button.tsx`)
  - MessageSquare icon positioned above user profile in sidebar
  - Tooltip showing keyboard shortcut (⌘⇧F)
  - Global keyboard shortcut to open dialog
  
- **GeneralFeedbackDialog** (`general-feedback-dialog.tsx`)
  - Clean dialog with large textarea for feedback
  - Image attachment button (placeholder for future implementation)
  - Submit with ⌘↵ keyboard shortcut
  - Toast notifications for user feedback
  - Email configured to `hello@goalive.nl`

### Updated Components
- **IntegratedAside** - Added FeedbackButton above UserProfile

## Implementation Details

- Frontend-only (no API integration yet)
- Uses existing Dialog, Textarea, Button, and Tooltip components
- Keyboard shortcuts:
  - ⌘⇧F: Open feedback dialog
  - ⌘↵: Submit feedback (when dialog is open)
- Success toast shown on submission (actual API to be implemented)

## Testing

- ✅ TypeScript type checking passed
- ✅ Lint-staged formatting passed
- ✅ Smoke tests passed
- ✅ All pre-push hooks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a feedback button in the sidebar with a simple dialog and keyboard shortcuts so users can quickly share feedback. Frontend-only for now with a success toast on submit.

- **New Features**
  - Feedback button above the user profile in the sidebar.
  - Global shortcut ⌘⇧F to open the dialog; ⌘↵ to submit.
  - Dialog with large textarea and email shown (hello@goalive.nl).
  - Image attachment button (placeholder, no upload yet).

<!-- End of auto-generated description by cubic. -->

