### PR TITLE
feat(workflow): add clerk_id to workflow creation

### DIFF
--- a/apps/web/src/app/api/workflow/upsert-workflow/route.ts
+++ b/apps/web/src/app/api/workflow/upsert-workflow/route.ts
@@ -46,7 +46,7 @@ export async function POST(request: NextRequest) {
         return NextResponse.json({ error: "workflowName is required for new workflows" }, { status: 400 })
       }
       workflowId = `wf_id_${genShortId()}`
-      await createWorkflow(workflowId, workflowName)
+      await createWorkflow(workflowId, workflowName, authResult)
 
       // Try to save the version, but rollback workflow creation if it fails
       try {

--- a/apps/web/src/trace-visualization/db/Workflow/retrieveWorkflow.ts
+++ b/apps/web/src/trace-visualization/db/Workflow/retrieveWorkflow.ts
@@ -56,11 +56,16 @@ export const retrieveWorkflow = async (workflowId: string): Promise<Tables<"Work
   return data
 }
 
-export const createWorkflow = async (workflowId: string, description: string): Promise<Tables<"Workflow">> => {
+export const createWorkflow = async (
+  workflowId: string,
+  description: string,
+  clerkId: string,
+): Promise<Tables<"Workflow">> => {
   const supabase = await createRLSClient()
   const workflowInsertable: TablesInsert<"Workflow"> = {
     wf_id: workflowId,
     description,
+    clerk_id: clerkId,
   }
 
   const { data, error } = await supabase.from("Workflow").insert(workflowInsertable).select().single()

--- a/packages/shared/src/types/database.types.ts
+++ b/packages/shared/src/types/database.types.ts
@@ -301,6 +301,33 @@ export type Database = {
         }
         Relationships: []
       }
+      feedback: {
+        Row: {
+          clerk_id: string | null
+          content: string
+          context: string | null
+          created_at: string | null
+          feedback_id: string
+          status: string | null
+        }
+        Insert: {
+          clerk_id?: string | null
+          content: string
+          context?: string | null
+          created_at?: string | null
+          feedback_id?: string
+          status?: string | null
+        }
+        Update: {
+          clerk_id?: string | null
+          content?: string
+          context?: string | null
+          created_at?: string | null
+          feedback_id?: string
+          status?: string | null
+        }
+        Relationships: []
+      }
       Generation: {
         Row: {
           best_workflow_version_id: string | null


### PR DESCRIPTION
## Summary
Add clerk_id tracking to workflow creation to associate workflows with authenticated users.

## Changes
- Updated `createWorkflow()` function in `apps/web/src/trace-visualization/db/Workflow/retrieveWorkflow.ts` to accept and store `clerk_id` parameter
- Modified workflow creation API route in `apps/web/src/app/api/workflow/upsert-workflow/route.ts` to pass authenticated user's clerk_id
- Database schema already supports clerk_id field (optional)

## Test plan
- [ ] Verify workflow creation saves clerk_id correctly
- [ ] Test that existing workflows without clerk_id still work
- [ ] Confirm authentication is properly enforced

🤖 Generated with [Claude Code](https://claude.com/claude-code)