### PR TITLE
feat(web): route to latest version when loading workflows

### DIFF
--- a/apps/web/src/app/(editor)/edit/[wf_version_id]/page.tsx
+++ b/apps/web/src/app/(editor)/edit/[wf_version_id]/page.tsx
@@ -15,6 +15,7 @@ export default function WorkflowVersionEditor({ params }: PageProps) {
   const [workflowVersion, setWorkflowVersion] = useState(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(false)
+  const [redirecting, setRedirecting] = useState(false)
   const router = useRouter()
 
   useEffect(() => {
@@ -33,21 +34,23 @@ export default function WorkflowVersionEditor({ params }: PageProps) {
 
             if (latestVersion?.wf_version_id) {
               // Redirect to the latest version
+              setRedirecting(true)
               router.replace(`/edit/${latestVersion.wf_version_id}`)
               return
             }
           }
 
           setError(true)
+          setLoading(false)
           return
         }
 
         const data = await response.json()
         setWorkflowVersion(data)
+        setLoading(false)
       } catch (err) {
         console.error("Failed to load workflow version:", err)
         setError(true)
-      } finally {
         setLoading(false)
       }
     }
@@ -55,7 +58,7 @@ export default function WorkflowVersionEditor({ params }: PageProps) {
     loadWorkflow()
   }, [params, router])
 
-  if (loading) return <div>Loading...</div>
+  if (loading || redirecting) return <div>Loading...</div>
   if (error) notFound()
   if (!workflowVersion) notFound()
 

--- a/apps/web/src/app/(editor)/edit/[wf_version_id]/page.tsx
+++ b/apps/web/src/app/(editor)/edit/[wf_version_id]/page.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { AppStoreProvider } from "@/react-flow-visualization/store/store"
-import { notFound } from "next/navigation"
+import { notFound, useRouter } from "next/navigation"
 import { useEffect, useState } from "react"
 import EditModeSelector from "../components/EditModeSelector"
 
@@ -15,6 +15,7 @@ export default function WorkflowVersionEditor({ params }: PageProps) {
   const [workflowVersion, setWorkflowVersion] = useState(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(false)
+  const router = useRouter()
 
   useEffect(() => {
     async function loadWorkflow() {
@@ -23,6 +24,20 @@ export default function WorkflowVersionEditor({ params }: PageProps) {
         const response = await fetch(`/api/workflow/version/${wf_version_id}`)
 
         if (!response.ok) {
+          // If version not found, try to fetch as workflow ID and get latest version
+          const workflowResponse = await fetch(`/api/workflow/${wf_version_id}`)
+
+          if (workflowResponse.ok) {
+            const workflowData = await workflowResponse.json()
+            const latestVersion = workflowData.versions?.[0]
+
+            if (latestVersion?.wf_version_id) {
+              // Redirect to the latest version
+              router.replace(`/edit/${latestVersion.wf_version_id}`)
+              return
+            }
+          }
+
           setError(true)
           return
         }
@@ -38,7 +53,7 @@ export default function WorkflowVersionEditor({ params }: PageProps) {
     }
 
     loadWorkflow()
-  }, [params])
+  }, [params, router])
 
   if (loading) return <div>Loading...</div>
   if (error) notFound()

--- a/apps/web/src/app/api/workflow/[wf_id]/route.ts
+++ b/apps/web/src/app/api/workflow/[wf_id]/route.ts
@@ -1,0 +1,42 @@
+import { requireAuth } from "@/lib/api-auth"
+import { createClient } from "@/lib/supabase/server"
+import { type NextRequest, NextResponse } from "next/server"
+
+export const dynamic = "force-dynamic"
+
+export async function GET(request: NextRequest, context: { params: Promise<{ wf_id: string }> }) {
+  const authResult = await requireAuth()
+  if (authResult instanceof NextResponse) return authResult
+
+  const supabase = await createClient()
+  const { wf_id } = await context.params
+
+  try {
+    const { data, error } = await supabase
+      .from("Workflow")
+      .select(
+        `
+        *,
+        versions:WorkflowVersion(*)
+      `,
+      )
+      .eq("wf_id", wf_id)
+      .single()
+
+    if (error || !data) {
+      return NextResponse.json({ error: error?.message || "Workflow not found" }, { status: 404 })
+    }
+
+    const sortedVersions = (data.versions || []).sort(
+      (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
+    )
+
+    return NextResponse.json({
+      ...data,
+      versions: sortedVersions,
+    })
+  } catch (error) {
+    console.error("Error fetching workflow:", error)
+    return NextResponse.json({ error: "Failed to fetch workflow" }, { status: 500 })
+  }
+}

--- a/apps/web/src/app/workflows/page.tsx
+++ b/apps/web/src/app/workflows/page.tsx
@@ -22,6 +22,9 @@ function WorkflowRow({
   const versionCount = workflow.versionCount || 0
   const timeAgo = workflow.updated_at ? formatTimeAgo(new Date(workflow.updated_at)) : null
 
+  const latestVersionId = workflow.activeVersion?.wf_version_id
+  const editHref = latestVersionId ? `/edit/${latestVersionId}` : `/edit/${workflow.wf_id}`
+
   return (
     <div className="relative flex items-center gap-4 px-4 h-14 border-b border-border/30 hover:bg-black/[0.03] dark:hover:bg-white/[0.06] transition-all duration-[80ms] ease-out group">
       <div
@@ -32,7 +35,7 @@ function WorkflowRow({
       {/* Name/Description */}
       <div className="flex-1 min-w-0">
         <Link
-          href={`/edit/${workflow.wf_id}`}
+          href={editHref}
           className="font-semibold text-[14px] leading-[20px] text-foreground hover:underline truncate block"
           title={workflow.description}
         >
@@ -96,7 +99,7 @@ function WorkflowRow({
         </button>
 
         <Link
-          href={`/edit/${workflow.wf_id}`}
+          href={editHref}
           className="inline-flex items-center gap-1.5 px-3 py-1.5 text-[12px] font-medium rounded-md bg-secondary text-secondary-foreground hover:bg-secondary/80 transition-all duration-[80ms] ease-out active:scale-[0.98] focus:outline-none focus:ring-2 focus:ring-primary/70 focus:ring-offset-2"
         >
           <Pencil className="size-3" />


### PR DESCRIPTION
## Summary
When users click on a workflow from the dashboard, the app now navigates to the latest version (`/edit/{versionId}`) instead of the workflow ID (`/edit/{wfId}`).

## Changes
- Modified `WorkflowRow` component in `apps/web/src/app/workflows/page.tsx`
- Extract latest version ID from `workflow.activeVersion?.wf_version_id`
- Use latest version ID for both the workflow name link and the "Edit" button
- Falls back to workflow ID if no active version exists

## Test plan
- [x] Typecheck passes
- [x] Smoke tests pass
- [x] Unit tests pass
- [ ] Manually test: Click on a workflow from `/workflows` page
- [ ] Verify: URL should be `/edit/{versionId}` instead of `/edit/{wfId}`
- [ ] Verify: Workflow loads with the latest version

🤖 Generated with [Claude Code](https://claude.com/claude-code)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Route users to the latest workflow version when opening from the dashboard or hitting /edit with a workflow ID, improving consistency and reducing confusion.

- **New Features**
  - Dashboard links and the Edit button now open /edit/{versionId}; fall back to /edit/{wfId} if no active version.
  - Edit page supports workflow IDs and redirects to the newest version when needed.
  - Added /api/workflow/[wf_id] to fetch a workflow with versions sorted by created_at for redirect logic.

<!-- End of auto-generated description by cubic. -->

