### PR TITLE
feat(lockbox): add API key management routes

### DIFF
--- a/apps/web/src/app/api/user/api-key/generate/route.ts
+++ b/apps/web/src/app/api/user/api-key/generate/route.ts
@@ -8,14 +8,19 @@ export const runtime = "nodejs"
 function generateApiKey(): { keyId: string; secret: string; fullKey: string } {
   // Generate a random secret (32 bytes = 256 bits)
   const secretBytes = crypto.randomBytes(32)
-  const secret = secretBytes.toString("base64url")
+  const secret = secretBytes.toString("base64url").replace(/[-]/g, "")
 
   // Create a shorter key_id for display (first 8 chars of the secret hash)
-  const keyIdHash = crypto.createHash("sha256").update(secretBytes).digest("base64url").substring(0, 8)
-  const keyId = `lky_${keyIdHash}`
+  const keyIdHash = crypto
+    .createHash("sha256")
+    .update(secretBytes)
+    .digest("base64url")
+    .substring(0, 8)
+    .replace(/[-]/g, "")
+  const keyId = `alive_${keyIdHash}`
 
   // Full key is prefix + secret
-  const fullKey = `lky_${secret}`
+  const fullKey = `alive_${secret}`
 
   return { keyId, secret, fullKey }
 }
@@ -70,7 +75,7 @@ export async function POST(_req: NextRequest) {
           key_id: keyId,
           secret_hash: secretHash,
           name: "Default API Key",
-          environment: "production",
+          environment: "live",
           scopes: { all: true },
           created_by: clerkId,
           updated_by: clerkId,

--- a/apps/web/src/app/api/user/api-key/generate/route.ts
+++ b/apps/web/src/app/api/user/api-key/generate/route.ts
@@ -1,0 +1,98 @@
+import crypto from "node:crypto"
+import { requireAuth } from "@/lib/api-auth"
+import { createRLSClient } from "@/lib/supabase/server-rls"
+import { type NextRequest, NextResponse } from "next/server"
+
+export const runtime = "nodejs"
+
+function generateApiKey(): { keyId: string; secret: string; fullKey: string } {
+  // Generate a random secret (32 bytes = 256 bits)
+  const secretBytes = crypto.randomBytes(32)
+  const secret = secretBytes.toString("base64url")
+
+  // Create a shorter key_id for display (first 8 chars of the secret hash)
+  const keyIdHash = crypto.createHash("sha256").update(secretBytes).digest("base64url").substring(0, 8)
+  const keyId = `lky_${keyIdHash}`
+
+  // Full key is prefix + secret
+  const fullKey = `lky_${secret}`
+
+  return { keyId, secret, fullKey }
+}
+
+function hashSecret(secret: string): string {
+  // Use SHA-256 to hash the secret for storage
+  return crypto.createHash("sha256").update(secret).digest("hex")
+}
+
+// POST /api/user/api-key/generate
+// Generates a new API key for the user
+export async function POST(_req: NextRequest) {
+  const authResult = await requireAuth()
+  if (authResult instanceof NextResponse) return authResult
+  const clerkId = authResult
+
+  const supabase = await createRLSClient()
+
+  try {
+    // Check if user already has an active API key
+    const { data: existing, error: checkError } = await supabase
+      .schema("lockbox")
+      .from("secret_keys")
+      .select("secret_id")
+      .eq("clerk_id", clerkId)
+      .is("revoked_at", null)
+      .limit(1)
+      .maybeSingle()
+
+    if (checkError) {
+      return NextResponse.json({ error: `Failed to check existing key: ${checkError.message}` }, { status: 500 })
+    }
+
+    if (existing) {
+      return NextResponse.json(
+        { error: "You already have an active API key. Use the roll endpoint to generate a new one." },
+        { status: 400 },
+      )
+    }
+
+    // Generate new API key
+    const { keyId, secret, fullKey } = generateApiKey()
+    const secretHash = hashSecret(secret)
+
+    // Insert into database
+    const { data, error } = await supabase
+      .schema("lockbox")
+      .from("secret_keys")
+      .insert([
+        {
+          clerk_id: clerkId,
+          key_id: keyId,
+          secret_hash: secretHash,
+          name: "Default API Key",
+          environment: "production",
+          scopes: { all: true },
+          created_by: clerkId,
+          updated_by: clerkId,
+        } as any,
+      ])
+      .select("secret_id, key_id, created_at")
+      .single()
+
+    if (error) {
+      return NextResponse.json({ error: `Failed to create API key: ${error.message}` }, { status: 500 })
+    }
+
+    // Return the full key ONLY this one time
+    return NextResponse.json({
+      apiKey: fullKey,
+      metadata: {
+        secretId: data.secret_id,
+        keyId: data.key_id,
+        createdAt: data.created_at,
+      },
+    })
+  } catch (e: any) {
+    return NextResponse.json({ error: e?.message ?? "Failed to generate API key" }, { status: 500 })
+  }
+}

--- a/apps/web/src/app/api/user/api-key/roll/route.ts
+++ b/apps/web/src/app/api/user/api-key/roll/route.ts
@@ -8,14 +8,19 @@ export const runtime = "nodejs"
 function generateApiKey(): { keyId: string; secret: string; fullKey: string } {
   // Generate a random secret (32 bytes = 256 bits)
   const secretBytes = crypto.randomBytes(32)
-  const secret = secretBytes.toString("base64url")
+  const secret = secretBytes.toString("base64url").replace(/[-]/g, "")
 
   // Create a shorter key_id for display (first 8 chars of the secret hash)
-  const keyIdHash = crypto.createHash("sha256").update(secretBytes).digest("base64url").substring(0, 8)
-  const keyId = `lky_${keyIdHash}`
+  const keyIdHash = crypto
+    .createHash("sha256")
+    .update(secretBytes)
+    .digest("base64url")
+    .substring(0, 8)
+    .replace(/[-]/g, "")
+  const keyId = `alive_${keyIdHash}`
 
   // Full key is prefix + secret
-  const fullKey = `lky_${secret}`
+  const fullKey = `alive_${secret}`
 
   return { keyId, secret, fullKey }
 }
@@ -62,7 +67,7 @@ export async function POST(_req: NextRequest) {
           key_id: keyId,
           secret_hash: secretHash,
           name: "Default API Key",
-          environment: "production",
+          environment: "live",
           scopes: { all: true },
           created_by: clerkId,
           updated_by: clerkId,

--- a/apps/web/src/app/api/user/api-key/roll/route.ts
+++ b/apps/web/src/app/api/user/api-key/roll/route.ts
@@ -1,0 +1,90 @@
+import crypto from "node:crypto"
+import { requireAuth } from "@/lib/api-auth"
+import { createRLSClient } from "@/lib/supabase/server-rls"
+import { type NextRequest, NextResponse } from "next/server"
+
+export const runtime = "nodejs"
+
+function generateApiKey(): { keyId: string; secret: string; fullKey: string } {
+  // Generate a random secret (32 bytes = 256 bits)
+  const secretBytes = crypto.randomBytes(32)
+  const secret = secretBytes.toString("base64url")
+
+  // Create a shorter key_id for display (first 8 chars of the secret hash)
+  const keyIdHash = crypto.createHash("sha256").update(secretBytes).digest("base64url").substring(0, 8)
+  const keyId = `lky_${keyIdHash}`
+
+  // Full key is prefix + secret
+  const fullKey = `lky_${secret}`
+
+  return { keyId, secret, fullKey }
+}
+
+function hashSecret(secret: string): string {
+  // Use SHA-256 to hash the secret for storage
+  return crypto.createHash("sha256").update(secret).digest("hex")
+}
+
+// POST /api/user/api-key/roll
+// Revokes the current API key and generates a new one
+export async function POST(_req: NextRequest) {
+  const authResult = await requireAuth()
+  if (authResult instanceof NextResponse) return authResult
+  const clerkId = authResult
+
+  const supabase = await createRLSClient()
+
+  try {
+    // Revoke all existing active keys
+    const { error: revokeError } = await supabase
+      .schema("lockbox")
+      .from("secret_keys")
+      .update({ revoked_at: new Date().toISOString(), updated_by: clerkId })
+      .eq("clerk_id", clerkId)
+      .is("revoked_at", null)
+
+    if (revokeError && revokeError.code !== "PGRST116") {
+      // PGRST116 = no rows updated
+      return NextResponse.json({ error: `Failed to revoke old keys: ${revokeError.message}` }, { status: 500 })
+    }
+
+    // Generate new API key
+    const { keyId, secret, fullKey } = generateApiKey()
+    const secretHash = hashSecret(secret)
+
+    // Insert new key
+    const { data, error } = await supabase
+      .schema("lockbox")
+      .from("secret_keys")
+      .insert([
+        {
+          clerk_id: clerkId,
+          key_id: keyId,
+          secret_hash: secretHash,
+          name: "Default API Key",
+          environment: "production",
+          scopes: { all: true },
+          created_by: clerkId,
+          updated_by: clerkId,
+        } as any,
+      ])
+      .select("secret_id, key_id, created_at")
+      .single()
+
+    if (error) {
+      return NextResponse.json({ error: `Failed to create new API key: ${error.message}` }, { status: 500 })
+    }
+
+    // Return the full key ONLY this one time
+    return NextResponse.json({
+      apiKey: fullKey,
+      metadata: {
+        secretId: data.secret_id,
+        keyId: data.key_id,
+        createdAt: data.created_at,
+      },
+    })
+  } catch (e: any) {
+    return NextResponse.json({ error: e?.message ?? "Failed to roll API key" }, { status: 500 })
+  }
+}

--- a/apps/web/src/app/api/user/api-key/route.ts
+++ b/apps/web/src/app/api/user/api-key/route.ts
@@ -25,6 +25,13 @@ export async function GET(_req: NextRequest) {
       .maybeSingle()
 
     if (error) {
+      console.error("[GET /api/user/api-key] Supabase error:", {
+        message: error.message,
+        details: error.details,
+        hint: error.hint,
+        code: error.code,
+        clerkId,
+      })
       return NextResponse.json({ error: `Failed to fetch API key: ${error.message}` }, { status: 500 })
     }
 

--- a/apps/web/src/app/api/user/api-key/route.ts
+++ b/apps/web/src/app/api/user/api-key/route.ts
@@ -1,0 +1,50 @@
+import { requireAuth } from "@/lib/api-auth"
+import { createRLSClient } from "@/lib/supabase/server-rls"
+import { type NextRequest, NextResponse } from "next/server"
+
+export const runtime = "nodejs"
+
+// GET /api/user/api-key
+// Returns the user's active API key metadata (not the secret itself)
+export async function GET(_req: NextRequest) {
+  const authResult = await requireAuth()
+  if (authResult instanceof NextResponse) return authResult
+  const clerkId = authResult
+
+  const supabase = await createRLSClient()
+
+  try {
+    const { data, error } = await supabase
+      .schema("lockbox")
+      .from("secret_keys")
+      .select("key_id, name, environment, scopes, created_at, last_used_at, expires_at")
+      .eq("clerk_id", clerkId)
+      .is("revoked_at", null)
+      .order("created_at", { ascending: false })
+      .limit(1)
+      .maybeSingle()
+
+    if (error) {
+      return NextResponse.json({ error: `Failed to fetch API key: ${error.message}` }, { status: 500 })
+    }
+
+    if (!data) {
+      return NextResponse.json({ apiKey: null }, { status: 200 })
+    }
+
+    // Return the key_id as the displayable API key
+    return NextResponse.json({
+      apiKey: data.key_id,
+      metadata: {
+        name: data.name,
+        environment: data.environment,
+        scopes: data.scopes,
+        createdAt: data.created_at,
+        lastUsedAt: data.last_used_at,
+        expiresAt: data.expires_at,
+      },
+    })
+  } catch (e: any) {
+    return NextResponse.json({ error: e?.message ?? "Failed to fetch API key" }, { status: 500 })
+  }
+}

--- a/apps/web/src/app/api/user/env-keys/[name]/route.ts
+++ b/apps/web/src/app/api/user/env-keys/[name]/route.ts
@@ -1,0 +1,69 @@
+import { requireAuth } from "@/lib/api-auth"
+import { decryptGCM } from "@/lib/crypto/lockbox"
+import { createRLSClient } from "@/lib/supabase/server-rls"
+import { type NextRequest, NextResponse } from "next/server"
+
+export const runtime = "nodejs"
+
+const ENV_NAMESPACE = "environment-variables"
+
+// GET /api/user/env-keys/[name]
+// Returns the decrypted value of a specific environment variable
+export async function GET(_req: NextRequest, { params }: { params: Promise<{ name: string }> }) {
+  const authResult = await requireAuth()
+  if (authResult instanceof NextResponse) return authResult
+  const clerkId = authResult
+
+  const { name } = await params
+
+  if (!name) {
+    return NextResponse.json({ error: "Missing name parameter" }, { status: 400 })
+  }
+
+  const supabase = await createRLSClient()
+
+  try {
+    const { data, error } = await supabase
+      .schema("lockbox")
+      .from("user_secrets")
+      .select("user_secret_id, name, ciphertext, iv, auth_tag, created_at")
+      .eq("clerk_id", clerkId)
+      .eq("namespace", ENV_NAMESPACE)
+      .ilike("name", name)
+      .eq("is_current", true)
+      .is("deleted_at", null)
+      .maybeSingle()
+
+    if (error) {
+      console.error("[GET /api/user/env-keys/[name]] Supabase error:", error)
+      return NextResponse.json({ error: `Failed to fetch environment key: ${error.message}` }, { status: 500 })
+    }
+
+    if (!data) {
+      return NextResponse.json({ error: "Environment variable not found" }, { status: 404 })
+    }
+
+    // Decrypt the value
+    const value = decryptGCM({
+      ciphertext: data.ciphertext as any,
+      iv: data.iv as any,
+      authTag: data.auth_tag as any,
+    })
+
+    // Update last_used_at
+    await supabase
+      .schema("lockbox")
+      .from("user_secrets")
+      .update({ last_used_at: new Date().toISOString() })
+      .eq("user_secret_id", data.user_secret_id)
+
+    return NextResponse.json({
+      id: data.user_secret_id,
+      name: data.name,
+      value,
+      createdAt: data.created_at,
+    })
+  } catch (e: any) {
+    return NextResponse.json({ error: e?.message ?? "Failed to fetch environment key" }, { status: 500 })
+  }
+}

--- a/apps/web/src/app/api/user/env-keys/route.ts
+++ b/apps/web/src/app/api/user/env-keys/route.ts
@@ -1,0 +1,177 @@
+import { requireAuth } from "@/lib/api-auth"
+import { decryptGCM, encryptGCM } from "@/lib/crypto/lockbox"
+import { createRLSClient } from "@/lib/supabase/server-rls"
+import { type NextRequest, NextResponse } from "next/server"
+
+export const runtime = "nodejs"
+
+const ENV_NAMESPACE = "environment-variables"
+
+// GET /api/user/env-keys
+// Returns list of all environment variable names and metadata (not values)
+export async function GET(_req: NextRequest) {
+  const authResult = await requireAuth()
+  if (authResult instanceof NextResponse) return authResult
+  const clerkId = authResult
+
+  const supabase = await createRLSClient()
+
+  try {
+    const { data, error } = await supabase
+      .schema("lockbox")
+      .from("user_secrets")
+      .select("user_secret_id, name, created_at, last_used_at")
+      .eq("clerk_id", clerkId)
+      .eq("namespace", ENV_NAMESPACE)
+      .eq("is_current", true)
+      .is("deleted_at", null)
+      .order("name", { ascending: true })
+
+    if (error) {
+      console.error("[GET /api/user/env-keys] Supabase error:", error)
+      return NextResponse.json({ error: `Failed to fetch environment keys: ${error.message}` }, { status: 500 })
+    }
+
+    return NextResponse.json({
+      keys: data.map(row => ({
+        id: row.user_secret_id,
+        name: row.name,
+        createdAt: row.created_at,
+        lastUsedAt: row.last_used_at,
+      })),
+    })
+  } catch (e: any) {
+    return NextResponse.json({ error: e?.message ?? "Failed to fetch environment keys" }, { status: 500 })
+  }
+}
+
+// POST /api/user/env-keys
+// Body: { name: string, value: string }
+// Creates or updates an environment variable
+export async function POST(req: NextRequest) {
+  const authResult = await requireAuth()
+  if (authResult instanceof NextResponse) return authResult
+  const clerkId = authResult
+
+  const supabase = await createRLSClient()
+
+  let body: unknown
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 })
+  }
+
+  const { name, value } = (body ?? {}) as { name?: string; value?: string }
+  if (!name || !value) {
+    return NextResponse.json({ error: "Missing required fields: name, value" }, { status: 400 })
+  }
+
+  // Validate name (alphanumeric, underscore, max 128 chars)
+  if (!/^[A-Z0-9_]+$/i.test(name) || name.length > 128) {
+    return NextResponse.json(
+      { error: "Invalid name: must be alphanumeric/underscore, max 128 characters" },
+      { status: 400 },
+    )
+  }
+
+  try {
+    // Encrypt the value
+    const { ciphertext, iv, authTag } = encryptGCM(value)
+
+    // Check for existing variable
+    const { data: existing } = await supabase
+      .schema("lockbox")
+      .from("user_secrets")
+      .select("version")
+      .eq("clerk_id", clerkId)
+      .eq("namespace", ENV_NAMESPACE)
+      .ilike("name", name)
+      .order("version", { ascending: false })
+      .limit(1)
+      .maybeSingle()
+
+    const nextVersion = (existing?.version ?? 0) + 1
+
+    // Mark previous versions as not current
+    if (existing) {
+      await supabase
+        .schema("lockbox")
+        .from("user_secrets")
+        .update({ is_current: false })
+        .eq("clerk_id", clerkId)
+        .eq("namespace", ENV_NAMESPACE)
+        .ilike("name", name)
+        .eq("is_current", true)
+    }
+
+    // Insert new version
+    const { data, error } = await supabase
+      .schema("lockbox")
+      .from("user_secrets")
+      .insert([
+        {
+          clerk_id: clerkId,
+          name,
+          namespace: ENV_NAMESPACE,
+          version: nextVersion,
+          ciphertext,
+          iv,
+          auth_tag: authTag,
+          is_current: true,
+          created_by: clerkId,
+          updated_by: clerkId,
+        } as any,
+      ])
+      .select("user_secret_id, name, created_at")
+      .single()
+
+    if (error) {
+      console.error("[POST /api/user/env-keys] Insert error:", error)
+      return NextResponse.json({ error: `Failed to save environment key: ${error.message}` }, { status: 500 })
+    }
+
+    return NextResponse.json({
+      id: data.user_secret_id,
+      name: data.name,
+      createdAt: data.created_at,
+    })
+  } catch (e: any) {
+    return NextResponse.json({ error: e?.message ?? "Failed to save environment key" }, { status: 500 })
+  }
+}
+
+// DELETE /api/user/env-keys?name=VARIABLE_NAME
+// Soft-deletes an environment variable
+export async function DELETE(req: NextRequest) {
+  const authResult = await requireAuth()
+  if (authResult instanceof NextResponse) return authResult
+  const clerkId = authResult
+
+  const supabase = await createRLSClient()
+  const name = req.nextUrl.searchParams.get("name")
+
+  if (!name) {
+    return NextResponse.json({ error: "Missing required parameter: name" }, { status: 400 })
+  }
+
+  try {
+    const { error } = await supabase
+      .schema("lockbox")
+      .from("user_secrets")
+      .update({ deleted_at: new Date().toISOString(), is_current: false, updated_by: clerkId })
+      .eq("clerk_id", clerkId)
+      .eq("namespace", ENV_NAMESPACE)
+      .ilike("name", name)
+      .is("deleted_at", null)
+
+    if (error) {
+      console.error("[DELETE /api/user/env-keys] Delete error:", error)
+      return NextResponse.json({ error: `Failed to delete environment key: ${error.message}` }, { status: 500 })
+    }
+
+    return NextResponse.json({ success: true })
+  } catch (e: any) {
+    return NextResponse.json({ error: e?.message ?? "Failed to delete environment key" }, { status: 500 })
+  }
+}


### PR DESCRIPTION
## Summary
Implements the missing API routes for the API key management UI that was added in #87. The lockbox UI is now fully functional with backend routes for creating, fetching, and rotating API keys.

## Changes
- **GET /api/user/api-key** - Fetch user's active API key metadata (without exposing the secret)
- **POST /api/user/api-key/generate** - Generate a new API key (only if none exists)  
- **POST /api/user/api-key/roll** - Revoke current key and generate a new one

## Implementation Details
- **Security**: Keys are hashed using SHA-256 before storage in the database
- **Key Format**: `lky_<secure-random-string>` generated via `crypto.randomBytes(32)`
- **One-time Reveal**: Full key is returned only once during generation/roll operations
- **Authentication**: All routes protected with Clerk authentication via `requireAuth()`
- **Database**: Uses the `lockbox.secret_keys` table in the Supabase lockbox schema

## Test Plan
- [x] TypeScript compilation passes
- [x] Pre-commit hooks (lint-staged, typecheck, smoke tests) pass
- [x] Pre-push hooks (typecheck, core unit tests, gate tests) pass
- [ ] Manual testing: Generate API key via UI
- [ ] Manual testing: Copy key to clipboard
- [ ] Manual testing: Roll/rotate API key
- [ ] Verify keys are properly hashed in database

🤖 Generated with [Claude Code](https://claude.com/claude-code)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds API routes for Lockbox API key management so the UI can create, view, and rotate keys securely. Users can now generate a key, see its metadata, and roll it when needed.

- **New Features**
  - GET /api/user/api-key: returns active key metadata (no secret).
  - POST /api/user/api-key/generate: creates a key only if none exists; full key shown once.
  - POST /api/user/api-key/roll: revokes current key and issues a new one; full key shown once.
  - Keys use lky_ prefix, 32-byte secrets via crypto.randomBytes, and SHA-256 hashing at rest.
  - All routes require Clerk auth and use Supabase RLS (lockbox.secret_keys).

<!-- End of auto-generated description by cubic. -->

