### PR TITLE
feat(settings): ai provider

### DIFF
--- a/apps/web/src/app/api/providers/test-connection/route.ts
+++ b/apps/web/src/app/api/providers/test-connection/route.ts
@@ -1,0 +1,130 @@
+import type { LuckyProvider } from "@lucky/shared"
+import { NextResponse } from "next/server"
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json()
+    const { provider, apiKey } = body as { provider: LuckyProvider; apiKey: string }
+
+    if (!provider || !apiKey) {
+      return NextResponse.json({ error: "Missing provider or apiKey" }, { status: 400 })
+    }
+
+    // Test connection based on provider
+    let testResult: { success: boolean; error?: string; modelCount?: number }
+
+    switch (provider) {
+      case "openai":
+        testResult = await testOpenAIConnection(apiKey)
+        break
+      case "groq":
+        testResult = await testGroqConnection(apiKey)
+        break
+      case "openrouter":
+        testResult = await testOpenRouterConnection(apiKey)
+        break
+      default:
+        return NextResponse.json({ error: "Unknown provider" }, { status: 400 })
+    }
+
+    if (!testResult.success) {
+      return NextResponse.json({ error: testResult.error }, { status: 401 })
+    }
+
+    return NextResponse.json({ success: true, modelCount: testResult.modelCount })
+  } catch (error) {
+    console.error("Error testing provider connection:", error)
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 })
+  }
+}
+
+async function testOpenAIConnection(
+  apiKey: string,
+): Promise<{ success: boolean; error?: string; modelCount?: number }> {
+  try {
+    const response = await fetch("https://api.openai.com/v1/models", {
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+      },
+    })
+
+    if (!response.ok) {
+      const error = await response.json()
+      return {
+        success: false,
+        error: error.error?.message || "Invalid API key or authentication failed",
+      }
+    }
+
+    const data = await response.json()
+    return {
+      success: true,
+      modelCount: data.data?.length || 0,
+    }
+  } catch (_error) {
+    return {
+      success: false,
+      error: "Failed to connect to OpenAI API",
+    }
+  }
+}
+
+async function testGroqConnection(apiKey: string): Promise<{ success: boolean; error?: string; modelCount?: number }> {
+  try {
+    const response = await fetch("https://api.groq.com/openai/v1/models", {
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+      },
+    })
+
+    if (!response.ok) {
+      const error = await response.json()
+      return {
+        success: false,
+        error: error.error?.message || "Invalid API key or authentication failed",
+      }
+    }
+
+    const data = await response.json()
+    return {
+      success: true,
+      modelCount: data.data?.length || 0,
+    }
+  } catch (_error) {
+    return {
+      success: false,
+      error: "Failed to connect to Groq API",
+    }
+  }
+}
+
+async function testOpenRouterConnection(
+  apiKey: string,
+): Promise<{ success: boolean; error?: string; modelCount?: number }> {
+  try {
+    const response = await fetch("https://openrouter.ai/api/v1/models", {
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+      },
+    })
+
+    if (!response.ok) {
+      const error = await response.json()
+      return {
+        success: false,
+        error: error.error?.message || "Invalid API key or authentication failed",
+      }
+    }
+
+    const data = await response.json()
+    return {
+      success: true,
+      modelCount: data.data?.length || 0,
+    }
+  } catch (_error) {
+    return {
+      success: false,
+      error: "Failed to connect to OpenRouter API",
+    }
+  }
+}

--- a/apps/web/src/app/components/aside/aside-legacy.tsx
+++ b/apps/web/src/app/components/aside/aside-legacy.tsx
@@ -161,6 +161,9 @@ export function Aside() {
                 <SubNavItem href="/settings/developer" delay={100}>
                   Developer
                 </SubNavItem>
+                <SubNavItem href="/providers" delay={120}>
+                  Providers
+                </SubNavItem>
               </NavItem>
             </div>
           </nav>

--- a/apps/web/src/app/components/aside/integrated-aside.tsx
+++ b/apps/web/src/app/components/aside/integrated-aside.tsx
@@ -6,7 +6,7 @@ import { BarChart2, Boxes, Dna, Hammer, Home, Menu, Network, Plug, Settings, Wre
 import Link from "next/link"
 import { usePathname } from "next/navigation"
 import type React from "react"
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import { FeedbackButton } from "./feedback-button"
 import { UserProfile } from "./user-profile"
 
@@ -85,6 +85,10 @@ const navigationItems: NavItemData[] = [
     label: "Settings",
     icon: <Settings className="w-4 h-4" />,
     description: "Application settings",
+    submenus: [
+      { label: "General", href: "/settings" },
+      { label: "Providers", href: "/providers" },
+    ],
   },
 ]
 
@@ -188,6 +192,25 @@ export function IntegratedAside() {
   const [isHovered, setIsHovered] = useState(false)
   const { isMobile } = useSidebar()
 
+  // Auto-expand submenus when on a submenu route
+  useEffect(() => {
+    navigationItems.forEach(item => {
+      if (item.submenus) {
+        const isSubmenuActive = item.submenus.some(
+          submenu => pathname === submenu.href || pathname?.startsWith(`${submenu.href}/`),
+        )
+        if (isSubmenuActive) {
+          setOpenSubmenus(prev => {
+            if (!prev.has(item.href)) {
+              return new Set(prev).add(item.href)
+            }
+            return prev
+          })
+        }
+      }
+    })
+  }, [pathname])
+
   // Handle submenu toggle
   const toggleSubmenu = (href: string, e: React.MouseEvent) => {
     e.preventDefault()
@@ -243,7 +266,13 @@ export function IntegratedAside() {
           <nav className="w-full">
             <div className="flex flex-col gap-2">
               {navigationItems.map(item => {
-                const isActive = pathname === item.href || pathname?.startsWith(`${item.href}/`)
+                // Check if any submenu is active
+                const isSubmenuActive =
+                  item.submenus?.some(
+                    submenu => pathname === submenu.href || pathname?.startsWith(`${submenu.href}/`),
+                  ) ?? false
+
+                const isActive = pathname === item.href || pathname?.startsWith(`${item.href}/`) || isSubmenuActive
 
                 return (
                   <div key={item.href} className="group">
@@ -265,32 +294,44 @@ export function IntegratedAside() {
                           openSubmenus.has(item.href) ? "max-h-[500px]" : "max-h-0",
                         )}
                       >
-                        {item.submenus.map((submenu, index) => (
-                          <Link
-                            key={submenu.href}
-                            href={submenu.href}
-                            className="block group/child"
-                            onClick={handleNavClick}
-                          >
-                            <div className="relative">
-                              <div
-                                className={cn(
-                                  "ml-[35px] mr-[15px] h-[32px] flex items-center border-l border-[#DCDAD2] dark:border-[#2C2C2C] pl-3 transition-all duration-200 ease-out",
-                                  openSubmenus.has(item.href)
-                                    ? "opacity-100 translate-x-0"
-                                    : "opacity-0 -translate-x-2",
-                                )}
-                                style={{
-                                  transitionDelay: `${index * 20}ms`,
-                                }}
-                              >
-                                <span className="text-xs font-medium transition-colors duration-200 text-[#888] group-hover/child:text-primary whitespace-nowrap overflow-hidden">
-                                  {submenu.label}
-                                </span>
+                        {item.submenus.map((submenu, index) => {
+                          const isSubmenuItemActive =
+                            pathname === submenu.href || pathname?.startsWith(`${submenu.href}/`)
+
+                          return (
+                            <Link
+                              key={submenu.href}
+                              href={submenu.href}
+                              className="block group/child"
+                              onClick={handleNavClick}
+                            >
+                              <div className="relative">
+                                <div
+                                  className={cn(
+                                    "ml-[35px] mr-[15px] h-[32px] flex items-center border-l border-[#DCDAD2] dark:border-[#2C2C2C] pl-3 transition-all duration-200 ease-out",
+                                    openSubmenus.has(item.href)
+                                      ? "opacity-100 translate-x-0"
+                                      : "opacity-0 -translate-x-2",
+                                  )}
+                                  style={{
+                                    transitionDelay: `${index * 20}ms`,
+                                  }}
+                                >
+                                  <span
+                                    className={cn(
+                                      "text-xs font-medium transition-colors duration-200 whitespace-nowrap overflow-hidden",
+                                      isSubmenuItemActive
+                                        ? "text-primary"
+                                        : "text-[#888] group-hover/child:text-primary",
+                                    )}
+                                  >
+                                    {submenu.label}
+                                  </span>
+                                </div>
                               </div>
-                            </div>
-                          </Link>
-                        ))}
+                            </Link>
+                          )
+                        })}
                       </div>
                     )}
                   </div>

--- a/apps/web/src/app/components/aside/nav-item.tsx
+++ b/apps/web/src/app/components/aside/nav-item.tsx
@@ -32,7 +32,11 @@ export function NavItem({
           </div>
         </div>
       </a>
-      {hasSubmenu && <div className="transition-all duration-300 ease-out overflow-hidden max-h-0">{children}</div>}
+      {hasSubmenu && (
+        <div className="transition-all duration-300 ease-out overflow-hidden max-h-0 group-hover:max-h-[500px]">
+          {children}
+        </div>
+      )}
     </div>
   )
 }

--- a/apps/web/src/app/components/aside/sub-nav-item.tsx
+++ b/apps/web/src/app/components/aside/sub-nav-item.tsx
@@ -12,7 +12,7 @@ export function SubNavItem({ href, children, delay = 0, isActive = false }: SubN
     <a className="block group/child" href={href}>
       <div className="relative">
         <div
-          className="ml-[35px] mr-[15px] h-[32px] flex items-center border-l border-[#DCDAD2] dark:border-[#2C2C2C] pl-3 transition-all duration-200 ease-out opacity-0 -translate-x-2"
+          className="ml-[35px] mr-[15px] h-[32px] flex items-center border-l border-[#DCDAD2] dark:border-[#2C2C2C] pl-3 transition-all duration-200 ease-out opacity-0 -translate-x-2 group-hover:opacity-100 group-hover:translate-x-0"
           style={{ transitionDelay: `${delay}ms` }}
         >
           <span

--- a/apps/web/src/app/providers/analytics/page.tsx
+++ b/apps/web/src/app/providers/analytics/page.tsx
@@ -1,0 +1,347 @@
+"use client"
+
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { createClient } from "@/lib/supabase/client"
+import { Activity, Clock, DollarSign, TrendingUp, Zap } from "lucide-react"
+import { useEffect, useState } from "react"
+
+interface ModelStats {
+  model: string
+  invocations: number
+  totalCost: number
+  avgCost: number
+  totalDuration: number
+  avgDuration: number
+  successRate: number
+}
+
+interface ProviderStats {
+  provider: string
+  totalInvocations: number
+  totalCost: number
+  models: ModelStats[]
+}
+
+export default function ProvidersAnalyticsPage() {
+  const [providerStats, setProviderStats] = useState<ProviderStats[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [totalCost, setTotalCost] = useState(0)
+  const [totalInvocations, setTotalInvocations] = useState(0)
+
+  useEffect(() => {
+    loadAnalytics()
+  }, [])
+
+  const loadAnalytics = async () => {
+    try {
+      const supabase = createClient()
+
+      // Fetch node invocations with model data
+      const { data: invocations, error } = await supabase
+        .from("NodeInvocation")
+        .select("model, usd_cost, start_time, end_time, status")
+        .not("model", "is", null)
+        .order("start_time", { ascending: false })
+        .limit(1000)
+
+      if (error) {
+        console.error("Failed to load analytics:", error)
+        setIsLoading(false)
+        return
+      }
+
+      if (!invocations || invocations.length === 0) {
+        setIsLoading(false)
+        return
+      }
+
+      // Group by provider and model
+      const statsMap = new Map<string, Map<string, ModelStats>>()
+      let totalCostSum = 0
+      let totalInvocationsCount = 0
+
+      invocations.forEach(inv => {
+        const model = inv.model as string
+        const cost = inv.usd_cost || 0
+        const startTime = new Date(inv.start_time)
+        const endTime = inv.end_time ? new Date(inv.end_time) : null
+        const duration = endTime ? (endTime.getTime() - startTime.getTime()) / 1000 : 0
+        const isSuccess = inv.status === "completed"
+
+        // Determine provider from model name
+        let provider = "openrouter"
+        if (model.startsWith("openai/")) {
+          provider = "openai"
+        } else if (model.startsWith("groq/")) {
+          provider = "groq"
+        }
+
+        if (!statsMap.has(provider)) {
+          statsMap.set(provider, new Map())
+        }
+
+        const providerModels = statsMap.get(provider)!
+        if (!providerModels.has(model)) {
+          providerModels.set(model, {
+            model,
+            invocations: 0,
+            totalCost: 0,
+            avgCost: 0,
+            totalDuration: 0,
+            avgDuration: 0,
+            successRate: 0,
+          })
+        }
+
+        const modelStats = providerModels.get(model)!
+        modelStats.invocations++
+        modelStats.totalCost += cost
+        modelStats.totalDuration += duration
+        if (isSuccess) {
+          modelStats.successRate++
+        }
+
+        totalCostSum += cost
+        totalInvocationsCount++
+      })
+
+      // Calculate averages and format data
+      const formattedStats: ProviderStats[] = []
+
+      statsMap.forEach((models, provider) => {
+        let providerTotalInvocations = 0
+        let providerTotalCost = 0
+
+        const modelStats: ModelStats[] = []
+
+        models.forEach(stats => {
+          stats.avgCost = stats.totalCost / stats.invocations
+          stats.avgDuration = stats.totalDuration / stats.invocations
+          stats.successRate = (stats.successRate / stats.invocations) * 100
+
+          providerTotalInvocations += stats.invocations
+          providerTotalCost += stats.totalCost
+
+          modelStats.push(stats)
+        })
+
+        // Sort models by invocations
+        modelStats.sort((a, b) => b.invocations - a.invocations)
+
+        formattedStats.push({
+          provider,
+          totalInvocations: providerTotalInvocations,
+          totalCost: providerTotalCost,
+          models: modelStats,
+        })
+      })
+
+      // Sort providers by total cost
+      formattedStats.sort((a, b) => b.totalCost - a.totalCost)
+
+      setProviderStats(formattedStats)
+      setTotalCost(totalCostSum)
+      setTotalInvocations(totalInvocationsCount)
+    } catch (error) {
+      console.error("Failed to load analytics:", error)
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  const formatCurrency = (amount: number) => {
+    return new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: "USD",
+      minimumFractionDigits: 4,
+      maximumFractionDigits: 4,
+    }).format(amount)
+  }
+
+  const formatDuration = (seconds: number) => {
+    if (seconds < 1) {
+      return `${(seconds * 1000).toFixed(0)}ms`
+    }
+    if (seconds < 60) {
+      return `${seconds.toFixed(1)}s`
+    }
+    const minutes = Math.floor(seconds / 60)
+    const remainingSeconds = seconds % 60
+    return `${minutes}m ${remainingSeconds.toFixed(0)}s`
+  }
+
+  const getProviderIcon = (provider: string) => {
+    switch (provider) {
+      case "openai":
+        return "🤖"
+      case "groq":
+        return "⚡"
+      case "openrouter":
+        return "🌐"
+      default:
+        return "📊"
+    }
+  }
+
+  const getProviderName = (provider: string) => {
+    switch (provider) {
+      case "openai":
+        return "OpenAI"
+      case "groq":
+        return "Groq"
+      case "openrouter":
+        return "OpenRouter"
+      default:
+        return provider
+    }
+  }
+
+  if (isLoading) {
+    return (
+      <div className="container mx-auto py-8">
+        <div className="mb-8">
+          <h1 className="text-3xl font-semibold text-foreground mb-2">Provider Analytics</h1>
+          <p className="text-sm text-muted-foreground">Loading analytics data...</p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="container mx-auto py-8">
+      <div className="mb-8">
+        <h1 className="text-3xl font-semibold text-foreground mb-2">Provider Analytics</h1>
+        <p className="text-sm text-muted-foreground">Track model usage and costs across all providers</p>
+      </div>
+
+      {/* Summary Cards */}
+      <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-4 mb-8">
+        <Card>
+          <CardHeader className="pb-3">
+            <CardDescription className="flex items-center gap-2">
+              <Activity className="size-4" />
+              Total Invocations
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-semibold">{totalInvocations.toLocaleString()}</div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-3">
+            <CardDescription className="flex items-center gap-2">
+              <DollarSign className="size-4" />
+              Total Cost
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-semibold">{formatCurrency(totalCost)}</div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-3">
+            <CardDescription className="flex items-center gap-2">
+              <TrendingUp className="size-4" />
+              Active Providers
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-semibold">{providerStats.length}</div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-3">
+            <CardDescription className="flex items-center gap-2">
+              <Zap className="size-4" />
+              Avg Cost/Call
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-semibold">
+              {totalInvocations > 0 ? formatCurrency(totalCost / totalInvocations) : "$0.0000"}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Provider Breakdown */}
+      {providerStats.length === 0 ? (
+        <Card>
+          <CardContent className="py-12 text-center">
+            <Activity className="size-12 mx-auto text-muted-foreground mb-4" />
+            <h3 className="text-lg font-medium mb-2">No Analytics Data</h3>
+            <p className="text-sm text-muted-foreground">
+              Start using your workflows to see model usage analytics here.
+            </p>
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="space-y-6">
+          {providerStats.map(providerStat => (
+            <Card key={providerStat.provider}>
+              <CardHeader>
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-3">
+                    <div className="text-3xl">{getProviderIcon(providerStat.provider)}</div>
+                    <div>
+                      <CardTitle>{getProviderName(providerStat.provider)}</CardTitle>
+                      <CardDescription>
+                        {providerStat.totalInvocations.toLocaleString()} invocations •{" "}
+                        {formatCurrency(providerStat.totalCost)} total cost
+                      </CardDescription>
+                    </div>
+                  </div>
+                </div>
+              </CardHeader>
+              <CardContent>
+                <div className="space-y-3">
+                  {providerStat.models.map(modelStat => (
+                    <div key={modelStat.model} className="p-4 rounded-lg border">
+                      <div className="flex items-start justify-between mb-3">
+                        <div className="flex-1">
+                          <div className="font-mono text-sm font-medium mb-1">{modelStat.model}</div>
+                          <div className="flex items-center gap-3 text-xs text-muted-foreground">
+                            <span>{modelStat.invocations.toLocaleString()} calls</span>
+                            <span>•</span>
+                            <span>{formatCurrency(modelStat.totalCost)} total</span>
+                            <span>•</span>
+                            <span>{modelStat.successRate.toFixed(1)}% success</span>
+                          </div>
+                        </div>
+                        <Badge variant="outline" className="text-xs">
+                          {formatCurrency(modelStat.avgCost)}/call
+                        </Badge>
+                      </div>
+
+                      <div className="grid grid-cols-3 gap-4 pt-3 border-t text-xs">
+                        <div>
+                          <div className="text-muted-foreground mb-1">Avg Duration</div>
+                          <div className="font-medium flex items-center gap-1">
+                            <Clock className="size-3" />
+                            {formatDuration(modelStat.avgDuration)}
+                          </div>
+                        </div>
+                        <div>
+                          <div className="text-muted-foreground mb-1">Total Cost</div>
+                          <div className="font-medium">{formatCurrency(modelStat.totalCost)}</div>
+                        </div>
+                        <div>
+                          <div className="text-muted-foreground mb-1">Invocations</div>
+                          <div className="font-medium">{modelStat.invocations.toLocaleString()}</div>
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/app/providers/groq/page.tsx
+++ b/apps/web/src/app/providers/groq/page.tsx
@@ -1,0 +1,5 @@
+import { ProviderConfigPage } from "@/components/providers/provider-config-page"
+
+export default function GroqProviderPage() {
+  return <ProviderConfigPage provider="groq" />
+}

--- a/apps/web/src/app/providers/openai/page.tsx
+++ b/apps/web/src/app/providers/openai/page.tsx
@@ -1,0 +1,5 @@
+import { ProviderConfigPage } from "@/components/providers/provider-config-page"
+
+export default function OpenAIProviderPage() {
+  return <ProviderConfigPage provider="openai" />
+}

--- a/apps/web/src/app/providers/openrouter/page.tsx
+++ b/apps/web/src/app/providers/openrouter/page.tsx
@@ -1,0 +1,5 @@
+import { ProviderConfigPage } from "@/components/providers/provider-config-page"
+
+export default function OpenRouterProviderPage() {
+  return <ProviderConfigPage provider="openrouter" />
+}

--- a/apps/web/src/app/providers/page.tsx
+++ b/apps/web/src/app/providers/page.tsx
@@ -1,0 +1,269 @@
+"use client"
+
+import { ProviderOverviewSkeleton } from "@/components/providers/provider-skeleton"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { EnvironmentKeysManager } from "@/lib/environment-keys"
+import { PROVIDER_CONFIGS, getEnabledModelsKey } from "@/lib/providers/provider-utils"
+import type { LuckyProvider } from "@lucky/shared"
+import { AlertCircle, ArrowRight, CheckCircle2, DollarSign, Key, TrendingUp, Zap } from "lucide-react"
+import Link from "next/link"
+import { useEffect, useState } from "react"
+
+type ProviderStatus = "configured" | "partial" | "unconfigured"
+
+interface ProviderCardData {
+  provider: LuckyProvider
+  status: ProviderStatus
+  enabledModels: number
+  totalModels: number
+}
+
+export default function ProvidersPage() {
+  const [providers, setProviders] = useState<ProviderCardData[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [configuredCount, setConfiguredCount] = useState(0)
+
+  useEffect(() => {
+    loadProviders()
+  }, [])
+
+  const loadProviders = () => {
+    setIsLoading(true)
+    try {
+      const keys = EnvironmentKeysManager.getKeys()
+      const keyMap = Object.fromEntries(keys.map(k => [k.name, k.value]))
+
+      const providerData: ProviderCardData[] = (Object.keys(PROVIDER_CONFIGS) as LuckyProvider[]).map(provider => {
+        const config = PROVIDER_CONFIGS[provider]
+        const hasKey = !!keyMap[config.apiKeyName]
+
+        // Load enabled models
+        const savedModels = localStorage.getItem(getEnabledModelsKey(provider))
+        const enabledModels = savedModels ? JSON.parse(savedModels).length : 0
+
+        let status: ProviderStatus = "unconfigured"
+        if (hasKey && enabledModels > 0) {
+          status = "configured"
+        } else if (hasKey) {
+          status = "partial"
+        }
+
+        return {
+          provider,
+          status,
+          enabledModels,
+          totalModels: config.defaultModelsCount,
+        }
+      })
+
+      setProviders(providerData)
+      setConfiguredCount(providerData.filter(p => p.status === "configured").length)
+    } catch (error) {
+      console.error("Failed to load providers:", error)
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  const getStatusIcon = (status: ProviderStatus) => {
+    switch (status) {
+      case "configured":
+        return <CheckCircle2 className="size-5 text-green-500" />
+      case "partial":
+        return <AlertCircle className="size-5 text-yellow-500" />
+      case "unconfigured":
+        return <AlertCircle className="size-5 text-muted-foreground" />
+    }
+  }
+
+  const getStatusBadge = (status: ProviderStatus) => {
+    switch (status) {
+      case "configured":
+        return (
+          <Badge variant="outline" className="bg-green-50 text-green-700 border-green-200">
+            <CheckCircle2 className="size-3 mr-1" />
+            Ready
+          </Badge>
+        )
+      case "partial":
+        return (
+          <Badge variant="outline" className="bg-yellow-50 text-yellow-700 border-yellow-200">
+            <AlertCircle className="size-3 mr-1" />
+            Incomplete
+          </Badge>
+        )
+      case "unconfigured":
+        return (
+          <Badge variant="outline" className="bg-muted text-muted-foreground">
+            Not Configured
+          </Badge>
+        )
+    }
+  }
+
+  if (isLoading) {
+    return <ProviderOverviewSkeleton />
+  }
+
+  return (
+    <div className="container mx-auto py-8">
+      <div className="mb-8">
+        <h1 className="text-3xl font-semibold text-foreground mb-2">AI Providers</h1>
+        <p className="text-sm text-muted-foreground">
+          Configure your API keys and manage model access for each provider
+        </p>
+      </div>
+
+      {/* Summary Cards */}
+      <div className="grid gap-6 md:grid-cols-3 mb-8">
+        <Card>
+          <CardHeader className="pb-3">
+            <CardDescription className="flex items-center gap-2">
+              <CheckCircle2 className="size-4" />
+              Configured Providers
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-semibold">
+              {configuredCount} / {providers.length}
+            </div>
+            <p className="text-xs text-muted-foreground mt-1">
+              {configuredCount === providers.length
+                ? "All providers ready"
+                : `${providers.length - configuredCount} remaining`}
+            </p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-3">
+            <CardDescription className="flex items-center gap-2">
+              <Zap className="size-4" />
+              Total Models
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-semibold">{providers.reduce((sum, p) => sum + p.enabledModels, 0)}</div>
+            <p className="text-xs text-muted-foreground mt-1">
+              {providers.reduce((sum, p) => sum + p.totalModels, 0)}+ models available
+            </p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-3">
+            <CardDescription className="flex items-center gap-2">
+              <TrendingUp className="size-4" />
+              Quick Action
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Link href="/providers/analytics">
+              <Button variant="outline" size="sm" className="w-full">
+                <DollarSign className="size-4 mr-2" />
+                View Analytics
+              </Button>
+            </Link>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Provider Cards */}
+      <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3 mb-8">
+        {providers.map(providerData => {
+          const config = PROVIDER_CONFIGS[providerData.provider]
+          return (
+            <Card key={providerData.provider} className="hover:shadow-md transition-shadow">
+              <CardHeader>
+                <div className="flex items-start justify-between">
+                  <div className="flex items-center gap-3 flex-1 min-w-0">
+                    <div className="text-3xl shrink-0">{config.icon}</div>
+                    <div className="min-w-0">
+                      <CardTitle className="text-lg">{config.name}</CardTitle>
+                      <CardDescription className="text-xs mt-1">{config.description}</CardDescription>
+                    </div>
+                  </div>
+                  <div className="shrink-0">{getStatusIcon(providerData.status)}</div>
+                </div>
+              </CardHeader>
+              <CardContent>
+                <div className="space-y-4">
+                  <div className="flex items-center justify-between">
+                    <span className="text-sm text-muted-foreground">Status</span>
+                    {getStatusBadge(providerData.status)}
+                  </div>
+
+                  <div className="flex items-center justify-between">
+                    <span className="text-sm text-muted-foreground">Enabled Models</span>
+                    <span className="text-sm font-medium">
+                      {providerData.enabledModels} / {providerData.totalModels}+
+                    </span>
+                  </div>
+
+                  {providerData.status === "partial" && (
+                    <div className="flex items-start gap-2 p-2 rounded bg-yellow-50 border border-yellow-200">
+                      <AlertCircle className="size-4 text-yellow-600 mt-0.5 shrink-0" />
+                      <p className="text-xs text-yellow-700">API key configured but no models enabled</p>
+                    </div>
+                  )}
+
+                  <div className="pt-2">
+                    <Link href={`/providers/${config.slug}`}>
+                      <Button variant="outline" size="sm" className="w-full group">
+                        {providerData.status === "unconfigured" ? (
+                          <>
+                            <Key className="size-4 mr-2" />
+                            Configure Provider
+                          </>
+                        ) : (
+                          <>
+                            <Key className="size-4 mr-2" />
+                            Manage Settings
+                          </>
+                        )}
+                        <ArrowRight className="size-4 ml-auto group-hover:translate-x-0.5 transition-transform" />
+                      </Button>
+                    </Link>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          )
+        })}
+      </div>
+
+      {/* Help Card */}
+      {configuredCount === 0 && (
+        <Card className="bg-muted/50">
+          <CardContent className="py-8">
+            <div className="text-center max-w-2xl mx-auto space-y-4">
+              <div className="inline-flex items-center justify-center size-16 rounded-full bg-muted mb-2">
+                <Key className="size-8 text-muted-foreground" />
+              </div>
+              <div>
+                <h3 className="font-semibold text-lg mb-2">Get Started with AI Providers</h3>
+                <p className="text-sm text-muted-foreground mb-4">
+                  Configure at least one provider to start using AI models in your workflows. Each provider requires an
+                  API key and model selection.
+                </p>
+              </div>
+              <div className="flex flex-col sm:flex-row gap-3 justify-center">
+                <Link href="/providers/openai">
+                  <Button variant="outline">Configure OpenAI</Button>
+                </Link>
+                <Link href="/providers/groq">
+                  <Button variant="outline">Configure Groq</Button>
+                </Link>
+                <Link href="/providers/openrouter">
+                  <Button variant="outline">Configure OpenRouter</Button>
+                </Link>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/components/providers/provider-config-page.tsx
+++ b/apps/web/src/components/providers/provider-config-page.tsx
@@ -1,0 +1,471 @@
+"use client"
+
+import { ProviderConfigSkeleton } from "@/components/providers/provider-skeleton"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Switch } from "@/components/ui/switch"
+import { EnvironmentKeysManager } from "@/lib/environment-keys"
+import { fetchActiveModelNames } from "@/lib/models/client-utils"
+import {
+  PROVIDER_CONFIGS,
+  type ProviderConfig,
+  getEnabledModelsKey,
+  testConnection,
+  validateApiKey,
+} from "@/lib/providers/provider-utils"
+import { Input } from "@/react-flow-visualization/components/ui/input"
+import { Label } from "@/react-flow-visualization/components/ui/label"
+import type { LuckyProvider } from "@lucky/shared"
+import {
+  AlertCircle,
+  ArrowLeft,
+  CheckCircle2,
+  Copy,
+  ExternalLink,
+  Eye,
+  EyeOff,
+  Loader2,
+  RefreshCw,
+  Save,
+  Zap,
+} from "lucide-react"
+import Link from "next/link"
+import { useEffect, useState } from "react"
+import { toast } from "sonner"
+
+interface ProviderConfigPageProps {
+  provider: LuckyProvider
+}
+
+export function ProviderConfigPage({ provider }: ProviderConfigPageProps) {
+  const config = PROVIDER_CONFIGS[provider]
+
+  const [apiKey, setApiKey] = useState("")
+  const [isVisible, setIsVisible] = useState(false)
+  const [isLoading, setIsLoading] = useState(true)
+  const [isSaving, setIsSaving] = useState(false)
+  const [isTesting, setIsTesting] = useState(false)
+  const [isConfigured, setIsConfigured] = useState(false)
+  const [testStatus, setTestStatus] = useState<"idle" | "success" | "error">("idle")
+  const [availableModels, setAvailableModels] = useState<string[]>([])
+  const [enabledModels, setEnabledModels] = useState<Set<string>>(new Set())
+  const [validationError, setValidationError] = useState<string | null>(null)
+  const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false)
+
+  useEffect(() => {
+    loadConfiguration()
+    loadModels()
+  }, [])
+
+  const loadConfiguration = () => {
+    setIsLoading(true)
+    try {
+      const keys = EnvironmentKeysManager.getKeys()
+      const providerKey = keys.find(k => k.name === config.apiKeyName)
+
+      if (providerKey) {
+        setApiKey(providerKey.value)
+        setIsConfigured(true)
+      }
+
+      const savedEnabledModels = localStorage.getItem(getEnabledModelsKey(provider))
+      if (savedEnabledModels) {
+        setEnabledModels(new Set(JSON.parse(savedEnabledModels)))
+      }
+    } catch (error) {
+      console.error("Failed to load configuration:", error)
+      toast.error("Failed to load configuration")
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  const loadModels = async () => {
+    try {
+      const models = await fetchActiveModelNames(provider)
+      setAvailableModels(models as string[])
+
+      const savedEnabledModels = localStorage.getItem(getEnabledModelsKey(provider))
+      if (!savedEnabledModels) {
+        setEnabledModels(new Set(models as string[]))
+      }
+    } catch (error) {
+      console.error("Failed to load models:", error)
+      toast.error("Failed to load available models")
+    }
+  }
+
+  const handleApiKeyChange = (value: string) => {
+    setApiKey(value)
+    setHasUnsavedChanges(true)
+    setTestStatus("idle")
+    setValidationError(null)
+  }
+
+  const handleTestConnection = async () => {
+    const validation = validateApiKey(provider, apiKey)
+    if (!validation.valid) {
+      setValidationError(validation.error || null)
+      toast.error(validation.error)
+      return
+    }
+
+    setIsTesting(true)
+    setTestStatus("idle")
+    setValidationError(null)
+
+    try {
+      const result = await testConnection(provider, apiKey)
+
+      if (result.success) {
+        setTestStatus("success")
+        toast.success(`Connection successful! ${result.modelCount} models available.`)
+      } else {
+        setTestStatus("error")
+        toast.error(result.error || "Connection failed")
+        setValidationError(result.error || null)
+      }
+    } catch (_error) {
+      setTestStatus("error")
+      toast.error("Failed to test connection")
+    } finally {
+      setIsTesting(false)
+    }
+  }
+
+  const handleSave = () => {
+    const validation = validateApiKey(provider, apiKey)
+    if (!validation.valid) {
+      setValidationError(validation.error || null)
+      toast.error(validation.error)
+      return
+    }
+
+    if (enabledModels.size === 0) {
+      toast.error("Please enable at least one model")
+      return
+    }
+
+    setIsSaving(true)
+    try {
+      const keys = EnvironmentKeysManager.getKeys()
+      const existingKeyIndex = keys.findIndex(k => k.name === config.apiKeyName)
+
+      if (existingKeyIndex >= 0) {
+        keys[existingKeyIndex].value = apiKey
+      } else {
+        keys.push(EnvironmentKeysManager.createKey(config.apiKeyName, apiKey))
+      }
+
+      EnvironmentKeysManager.saveKeys(keys)
+      localStorage.setItem(getEnabledModelsKey(provider), JSON.stringify([...enabledModels]))
+
+      setIsConfigured(true)
+      setHasUnsavedChanges(false)
+      toast.success("Configuration saved successfully")
+    } catch (error) {
+      console.error("Failed to save configuration:", error)
+      toast.error("Failed to save configuration")
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  const toggleModel = (modelName: string) => {
+    const newEnabledModels = new Set(enabledModels)
+    if (newEnabledModels.has(modelName)) {
+      newEnabledModels.delete(modelName)
+    } else {
+      newEnabledModels.add(modelName)
+    }
+    setEnabledModels(newEnabledModels)
+    setHasUnsavedChanges(true)
+  }
+
+  const toggleAllModels = (enable: boolean) => {
+    setEnabledModels(enable ? new Set(availableModels) : new Set())
+    setHasUnsavedChanges(true)
+  }
+
+  const copyToClipboard = async (text: string) => {
+    try {
+      await navigator.clipboard.writeText(text)
+      toast.success("Copied to clipboard")
+    } catch (_error) {
+      toast.error("Failed to copy to clipboard")
+    }
+  }
+
+  if (isLoading) {
+    return <ProviderConfigSkeleton />
+  }
+
+  return (
+    <div className="container mx-auto py-8">
+      {/* Breadcrumb */}
+      <div className="mb-4">
+        <Link
+          href="/providers"
+          className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
+        >
+          <ArrowLeft className="size-4" />
+          Back to Providers
+        </Link>
+      </div>
+
+      {/* Header */}
+      <div className="mb-8">
+        <div className="flex flex-wrap items-center gap-3 mb-2">
+          <div className="text-4xl">{config.icon}</div>
+          <div className="flex-1 min-w-0">
+            <h1 className="text-3xl font-semibold text-foreground">{config.name} Configuration</h1>
+            <p className="text-sm text-muted-foreground">{config.description}</p>
+          </div>
+          {isConfigured && (
+            <Badge variant="outline" className="bg-green-50 text-green-700 border-green-200 shrink-0">
+              <CheckCircle2 className="size-3 mr-1" />
+              Configured
+            </Badge>
+          )}
+        </div>
+      </div>
+
+      <div className="max-w-4xl space-y-6">
+        {/* API Key Configuration */}
+        <Card>
+          <CardHeader>
+            <CardTitle>API Key</CardTitle>
+            <CardDescription>Your {config.name} API key for accessing models</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="api-key" className="text-sm font-medium">
+                  API Key
+                </Label>
+                <div className="flex flex-col sm:flex-row gap-2">
+                  <div className="relative flex-1">
+                    <Input
+                      id="api-key"
+                      type={isVisible ? "text" : "password"}
+                      placeholder={`${config.apiKeyPrefix}...`}
+                      value={apiKey}
+                      onChange={e => handleApiKeyChange(e.target.value)}
+                      className={`pr-16 font-mono text-sm ${validationError ? "border-destructive" : ""}`}
+                    />
+                    <div className="absolute right-1 top-1/2 -translate-y-1/2 flex gap-1">
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        className="size-7 p-0"
+                        onClick={() => setIsVisible(!isVisible)}
+                      >
+                        {isVisible ? <EyeOff className="size-4" /> : <Eye className="size-4" />}
+                      </Button>
+                      {apiKey && (
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          className="size-7 p-0"
+                          onClick={() => copyToClipboard(apiKey)}
+                        >
+                          <Copy className="size-4" />
+                        </Button>
+                      )}
+                    </div>
+                  </div>
+                  <Button
+                    variant="outline"
+                    onClick={handleTestConnection}
+                    disabled={!apiKey || isTesting}
+                    className="shrink-0 w-full sm:w-auto"
+                  >
+                    {isTesting ? (
+                      <>
+                        <Loader2 className="size-4 mr-2 animate-spin" />
+                        Testing...
+                      </>
+                    ) : testStatus === "success" ? (
+                      <>
+                        <CheckCircle2 className="size-4 mr-2 text-green-600" />
+                        Connected
+                      </>
+                    ) : (
+                      <>
+                        <RefreshCw className="size-4 mr-2" />
+                        Test Connection
+                      </>
+                    )}
+                  </Button>
+                </div>
+                {validationError && (
+                  <p className="text-xs text-destructive flex items-center gap-1">
+                    <AlertCircle className="size-3" />
+                    {validationError}
+                  </p>
+                )}
+                <p className="text-xs text-muted-foreground">
+                  Get your API key from{" "}
+                  <a
+                    href={config.keysUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-primary hover:underline inline-flex items-center gap-1"
+                  >
+                    {config.name} Platform
+                    <ExternalLink className="size-3" />
+                  </a>
+                </p>
+              </div>
+
+              {testStatus === "success" && (
+                <div className="flex items-start gap-3 p-3 rounded-lg bg-green-50 border border-green-200">
+                  <CheckCircle2 className="size-5 text-green-600 mt-0.5 shrink-0" />
+                  <div className="space-y-1">
+                    <p className="text-sm font-medium text-green-900">Connection Successful</p>
+                    <p className="text-xs text-green-700">Your API key is valid and working correctly.</p>
+                  </div>
+                </div>
+              )}
+
+              <div className="flex items-start gap-3 p-3 rounded-lg bg-muted/50">
+                <AlertCircle className="size-5 text-muted-foreground mt-0.5 shrink-0" />
+                <div className="space-y-1">
+                  <p className="text-sm font-medium text-foreground">Security Notice</p>
+                  <p className="text-xs text-muted-foreground">
+                    Your API key is stored locally in your browser. Keep it secure and never share it publicly.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Model Selection */}
+        <Card>
+          <CardHeader>
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <div>
+                <CardTitle>Model Selection</CardTitle>
+                <CardDescription>Choose which models are available in your workflows</CardDescription>
+              </div>
+              <Badge variant="outline">
+                {enabledModels.size} / {availableModels.length} enabled
+              </Badge>
+            </div>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-3">
+              {availableModels.length === 0 ? (
+                <div className="text-center py-8 text-muted-foreground">
+                  <Loader2 className="size-8 animate-spin mx-auto mb-2" />
+                  <p className="text-sm">Loading available models...</p>
+                </div>
+              ) : (
+                <>
+                  <div className="flex flex-wrap items-center justify-between pb-3 border-b gap-2">
+                    <p className="text-sm text-muted-foreground">Select models to enable</p>
+                    <div className="flex gap-2">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => toggleAllModels(false)}
+                        disabled={enabledModels.size === 0}
+                      >
+                        Disable All
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => toggleAllModels(true)}
+                        disabled={enabledModels.size === availableModels.length}
+                      >
+                        Enable All
+                      </Button>
+                    </div>
+                  </div>
+
+                  <div className="space-y-2 max-h-[500px] overflow-y-auto scrollbar-thin scrollbar-track-muted/20 scrollbar-thumb-border">
+                    {availableModels.map(model => (
+                      <div
+                        key={model}
+                        className="flex items-center justify-between p-3 rounded-lg border hover:bg-muted/50 transition-colors"
+                      >
+                        <div className="flex-1 min-w-0 mr-2">
+                          <div className="flex flex-wrap items-center gap-2">
+                            <span className="font-mono text-sm font-medium break-all">{model}</span>
+                            {(model.includes("mini") || model.includes("instant") || provider === "groq") && (
+                              <Badge
+                                variant="outline"
+                                className="text-xs bg-blue-50 text-blue-700 border-blue-200 shrink-0"
+                              >
+                                <Zap className="size-3 mr-1" />
+                                Fast
+                              </Badge>
+                            )}
+                            {(model.includes("4o") || model.includes("latest")) && (
+                              <Badge
+                                variant="outline"
+                                className="text-xs bg-purple-50 text-purple-700 border-purple-200 shrink-0"
+                              >
+                                Latest
+                              </Badge>
+                            )}
+                          </div>
+                        </div>
+                        <Switch checked={enabledModels.has(model)} onCheckedChange={() => toggleModel(model)} />
+                      </div>
+                    ))}
+                  </div>
+                </>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Actions */}
+        <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-4">
+          <div>
+            {hasUnsavedChanges && (
+              <p className="text-sm text-yellow-600 flex items-center gap-2">
+                <AlertCircle className="size-4" />
+                You have unsaved changes
+              </p>
+            )}
+          </div>
+          <div className="flex flex-col sm:flex-row gap-2">
+            <Button
+              variant="ghost"
+              onClick={() => {
+                loadConfiguration()
+                setHasUnsavedChanges(false)
+                setValidationError(null)
+                setTestStatus("idle")
+              }}
+              disabled={isSaving || !hasUnsavedChanges}
+              className="w-full sm:w-auto"
+            >
+              Reset
+            </Button>
+            <Button onClick={handleSave} disabled={isSaving || !hasUnsavedChanges} className="w-full sm:w-auto">
+              {isSaving ? (
+                <>
+                  <Loader2 className="size-4 mr-2 animate-spin" />
+                  Saving...
+                </>
+              ) : (
+                <>
+                  <Save className="size-4 mr-2" />
+                  Save Configuration
+                </>
+              )}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/providers/provider-skeleton.tsx
+++ b/apps/web/src/components/providers/provider-skeleton.tsx
@@ -1,0 +1,84 @@
+import { Card, CardContent, CardHeader } from "@/components/ui/card"
+import { Skeleton } from "@/components/ui/skeleton"
+
+export function ProviderConfigSkeleton() {
+  return (
+    <div className="container mx-auto py-8">
+      <div className="mb-8">
+        <div className="flex items-center gap-3 mb-2">
+          <Skeleton className="size-12 rounded-full" />
+          <div className="flex-1">
+            <Skeleton className="h-8 w-64 mb-2" />
+            <Skeleton className="h-4 w-96" />
+          </div>
+        </div>
+      </div>
+
+      <div className="max-w-4xl space-y-6">
+        <Card>
+          <CardHeader>
+            <Skeleton className="h-6 w-32 mb-2" />
+            <Skeleton className="h-4 w-64" />
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <Skeleton className="h-4 w-20" />
+                <Skeleton className="h-10 w-full" />
+                <Skeleton className="h-3 w-48" />
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <Skeleton className="h-6 w-40 mb-2" />
+            <Skeleton className="h-4 w-80" />
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-3">
+              {[1, 2, 3, 4, 5].map(i => (
+                <Skeleton key={i} className="h-16 w-full" />
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}
+
+export function ProviderOverviewSkeleton() {
+  return (
+    <div className="container mx-auto py-8">
+      <div className="mb-8">
+        <Skeleton className="h-8 w-64 mb-2" />
+        <Skeleton className="h-4 w-96" />
+      </div>
+
+      <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+        {[1, 2, 3].map(i => (
+          <Card key={i}>
+            <CardHeader>
+              <div className="flex items-center gap-3">
+                <Skeleton className="size-12 rounded-full" />
+                <div className="flex-1">
+                  <Skeleton className="h-6 w-32 mb-2" />
+                  <Skeleton className="h-3 w-48" />
+                </div>
+              </div>
+            </CardHeader>
+            <CardContent>
+              <div className="space-y-3">
+                <Skeleton className="h-6 w-full" />
+                <Skeleton className="h-6 w-full" />
+                <Skeleton className="h-10 w-full" />
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/ui/skeleton.tsx
+++ b/apps/web/src/components/ui/skeleton.tsx
@@ -1,0 +1,7 @@
+import { cn } from "@/lib/utils"
+
+function Skeleton({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("animate-pulse rounded-md bg-primary/10", className)} {...props} />
+}
+
+export { Skeleton }

--- a/apps/web/src/components/ui/switch.tsx
+++ b/apps/web/src/components/ui/switch.tsx
@@ -1,0 +1,29 @@
+"use client"
+
+import * as SwitchPrimitives from "@radix-ui/react-switch"
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Switch = React.forwardRef<
+  React.ComponentRef<typeof SwitchPrimitives.Root>,
+  React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>
+>(({ className, ...props }, ref) => (
+  <SwitchPrimitives.Root
+    className={cn(
+      "peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
+      className,
+    )}
+    {...props}
+    ref={ref}
+  >
+    <SwitchPrimitives.Thumb
+      className={cn(
+        "pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0",
+      )}
+    />
+  </SwitchPrimitives.Root>
+))
+Switch.displayName = SwitchPrimitives.Root.displayName
+
+export { Switch }

--- a/apps/web/src/lib/providers/provider-utils.ts
+++ b/apps/web/src/lib/providers/provider-utils.ts
@@ -1,0 +1,120 @@
+import type { LuckyProvider } from "@lucky/shared"
+
+export interface ProviderConfig {
+  name: string
+  slug: LuckyProvider
+  description: string
+  apiKeyName: string
+  apiKeyPrefix: string
+  icon: string
+  docsUrl: string
+  keysUrl: string
+  defaultModelsCount: number
+}
+
+export const PROVIDER_CONFIGS: Record<LuckyProvider, ProviderConfig> = {
+  openai: {
+    name: "OpenAI",
+    slug: "openai",
+    description: "Direct access to GPT models from OpenAI",
+    apiKeyName: "OPENAI_API_KEY",
+    apiKeyPrefix: "sk-",
+    icon: "🤖",
+    docsUrl: "https://platform.openai.com/docs",
+    keysUrl: "https://platform.openai.com/api-keys",
+    defaultModelsCount: 8,
+  },
+  groq: {
+    name: "Groq",
+    slug: "groq",
+    description: "Ultra-fast inference with Groq's LPU",
+    apiKeyName: "GROQ_API_KEY",
+    apiKeyPrefix: "gsk_",
+    icon: "⚡",
+    docsUrl: "https://console.groq.com/docs",
+    keysUrl: "https://console.groq.com/keys",
+    defaultModelsCount: 12,
+  },
+  openrouter: {
+    name: "OpenRouter",
+    slug: "openrouter",
+    description: "Access to 100+ models from multiple providers",
+    apiKeyName: "OPENROUTER_API_KEY",
+    apiKeyPrefix: "sk-or-v1-",
+    icon: "🌐",
+    docsUrl: "https://openrouter.ai/docs",
+    keysUrl: "https://openrouter.ai/keys",
+    defaultModelsCount: 150,
+  },
+}
+
+export function validateApiKey(provider: LuckyProvider, apiKey: string): { valid: boolean; error?: string } {
+  if (!apiKey || !apiKey.trim()) {
+    return { valid: false, error: "API key cannot be empty" }
+  }
+
+  const config = PROVIDER_CONFIGS[provider]
+
+  // Check prefix
+  if (!apiKey.startsWith(config.apiKeyPrefix)) {
+    return {
+      valid: false,
+      error: `${config.name} API keys must start with "${config.apiKeyPrefix}"`,
+    }
+  }
+
+  // Check minimum length
+  const minLength = config.apiKeyPrefix.length + 20
+  if (apiKey.length < minLength) {
+    return {
+      valid: false,
+      error: `API key appears too short (minimum ${minLength} characters)`,
+    }
+  }
+
+  // Check for whitespace
+  if (apiKey !== apiKey.trim()) {
+    return {
+      valid: false,
+      error: "API key contains leading or trailing whitespace",
+    }
+  }
+
+  return { valid: true }
+}
+
+export async function testConnection(
+  provider: LuckyProvider,
+  apiKey: string,
+): Promise<{ success: boolean; error?: string; modelCount?: number }> {
+  try {
+    const response = await fetch("/api/providers/test-connection", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ provider, apiKey }),
+    })
+
+    const result = await response.json()
+
+    if (!response.ok) {
+      return { success: false, error: result.error || "Connection test failed" }
+    }
+
+    return { success: true, modelCount: result.modelCount }
+  } catch (_error) {
+    return { success: false, error: "Network error during connection test" }
+  }
+}
+
+export function getEnabledModelsKey(provider: LuckyProvider): string {
+  return `${provider}_enabled_models`
+}
+
+export function getProviderStatus(
+  apiKey: string | undefined,
+  enabledModels: Set<string>,
+): "configured" | "partial" | "unconfigured" {
+  if (!apiKey) return "unconfigured"
+  if (enabledModels.size === 0) return "partial"
+  return "configured"
+}


### PR DESCRIPTION
## Summary
Add a comprehensive API provider configuration system with support for OpenAI, Groq, and OpenRouter providers.

## Changes
- **Navigation**: Add "Providers" submenu under Settings in sidebar
- **Provider Overview**: Dashboard showing configuration status and model counts
- **Provider Configuration Pages**: Individual pages for each provider with:
  - API key input, validation, and visibility toggle
  - Connection testing against actual provider APIs
  - Model selection and bulk enable/disable
  - Real-time validation and status feedback
- **Analytics**: Per-provider and per-model usage metrics:
  - Invocations, costs, duration, success rates
  - Data fetched from Supabase NodeInvocation table
- **Reusable Components**:
  - `ProviderConfigPage` for consistent provider UI
  - `ProviderConfigSkeleton` and `ProviderOverviewSkeleton` for loading states
  - `Switch` and `Skeleton` UI components
- **API Endpoint**: `/api/providers/test-connection` for validating provider API keys
- **UX Improvements**:
  - Auto-expand submenu when on provider routes
  - Active state detection for nested routes
  - Submenu items highlighted when active

## Technical Details
- Created 11 new files (pages, components, utilities)
- Renamed `aside.tsx` to `aside-legacy.tsx` (app uses `integrated-aside.tsx`)
- All changes pass type checking and smoke tests

## Test Plan
- [x] Type checking passes
- [x] Smoke tests pass
- [x] Navigate to `/providers` to see overview
- [x] Test individual provider configuration pages
- [ ] Verify API key validation works correctly
- [ ] Test connection functionality with real API keys
- [ ] Verify analytics display with real data
- [ ] Test on mobile/responsive layouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds a complete provider settings system for OpenAI, Groq, and OpenRouter, including API key management, model enable/disable, live connection testing, and usage analytics. Updates the Settings sidebar with a Providers submenu that auto-expands and highlights active routes.

- **New Features**
  - Providers overview (/providers) with per-provider status and enabled model counts.
  - Provider pages (/providers/openai, /providers/groq, /providers/openrouter):
    - API key input with prefix validation, visibility toggle, copy.
    - Live connection test via POST /api/providers/test-connection.
    - Model selection with bulk enable/disable and saved preferences.
  - Analytics (/providers/analytics): invocations, cost, duration, success rate per provider/model from Supabase NodeInvocation.
  - UI/Dev: ProviderConfigPage, loading skeletons, Switch component, provider-utils (validateApiKey, testConnection); sidebar submenu auto-expand and active highlighting; aside.tsx renamed to aside-legacy.tsx.

- **Migration**
  - Visit /providers to add keys and enable at least one model per provider.
  - Optional: View usage in /providers/analytics once data exists.

<!-- End of auto-generated description by cubic. -->

