### PR TITLE
feat(ui): add workflow invocation UI and fix demo workflow loading

### DIFF
--- a/apps/web/src/app/(editor)/edit/components/EditModeSelector.tsx
+++ b/apps/web/src/app/(editor)/edit/components/EditModeSelector.tsx
@@ -22,6 +22,7 @@ import DatasetSelector from "@/components/DatasetSelector"
 import WorkflowIOTable from "@/components/WorkflowIOTable"
 import { useRunConfigStore } from "@/stores/run-config-store"
 import { toWorkflowConfig } from "@lucky/core/workflow/schema/workflow.types"
+import WorkflowInvocationButton from "./WorkflowInvocationButton"
 
 async function loadFromDSLClientDisplay(dslConfig: any) {
   const response = await fetch("/api/workflow/verify", {
@@ -175,6 +176,24 @@ export default function EditModeSelector({ workflowVersion }: EditModeSelectorPr
 
   // Load initial data into graph when component mounts
   useEffect(() => {
+    // Check for demo workflow in sessionStorage first
+    const demoWorkflow = sessionStorage.getItem("demo_workflow")
+    if (demoWorkflow && !workflowVersion) {
+      try {
+        const workflow = JSON.parse(demoWorkflow) as WorkflowConfig
+        const jsonString = JSON.stringify(workflow, null, 2)
+        updateWorkflowJSON(jsonString)
+        loadWorkflowFromData(workflow).then(() => {
+          organizeLayout()
+        })
+        // Clear the demo workflow from sessionStorage after loading
+        sessionStorage.removeItem("demo_workflow")
+      } catch (error) {
+        console.error("Failed to load demo workflow:", error)
+      }
+      return
+    }
+
     if (
       workflowVersion?.dsl &&
       typeof workflowVersion.dsl === "object" &&
@@ -212,6 +231,7 @@ export default function EditModeSelector({ workflowVersion }: EditModeSelectorPr
   if (mode === "graph") {
     const graphActions = (
       <>
+        <WorkflowInvocationButton workflowVersionId={workflowVersion?.wf_version_id} />
         <Button
           onClick={organizeLayout}
           variant="ghost"

--- a/apps/web/src/app/(editor)/edit/components/WorkflowInvocationButton.tsx
+++ b/apps/web/src/app/(editor)/edit/components/WorkflowInvocationButton.tsx
@@ -1,0 +1,196 @@
+"use client"
+
+import { Button } from "@/components/ui/button"
+import { generateCurlCommand } from "@/lib/generate-curl-command"
+import { Check, Code, Copy, X } from "lucide-react"
+import { useState } from "react"
+
+type WorkflowInvocationButtonProps = {
+  workflowVersionId?: string
+}
+
+export default function WorkflowInvocationButton({ workflowVersionId }: WorkflowInvocationButtonProps) {
+  const [isOpen, setIsOpen] = useState(false)
+  const [copied, setCopied] = useState(false)
+
+  const curlCommand = workflowVersionId ? generateCurlCommand(workflowVersionId) : null
+
+  const handleCopy = async () => {
+    if (!curlCommand) return
+    try {
+      await navigator.clipboard.writeText(curlCommand)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch (err) {
+      console.error("Failed to copy:", err)
+    }
+  }
+
+  return (
+    <>
+      <Button
+        onClick={() => setIsOpen(true)}
+        variant="outline"
+        size="sm"
+        className="group relative"
+        data-testid="workflow-invocation-button"
+      >
+        <Code className="w-4 h-4 mr-1.5" />
+        <span className="opacity-80 group-hover:opacity-100">Invoke</span>
+      </Button>
+
+      {isOpen && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 backdrop-blur-sm">
+          <div className="bg-white rounded-xl max-w-3xl w-full mx-4 shadow-2xl transform transition-all">
+            {/* Header */}
+            <div className="px-6 py-4 border-b border-gray-200">
+              <div className="flex items-center justify-between">
+                <h3 className="text-lg font-semibold text-gray-900 flex items-center gap-2">
+                  <Code className="w-5 h-5 text-blue-600" />
+                  Invoke Workflow via API
+                </h3>
+                <Button onClick={() => setIsOpen(false)} variant="ghost" size="sm" className="h-auto p-1">
+                  <X className="w-5 h-5" />
+                </Button>
+              </div>
+              {!workflowVersionId ? (
+                <p className="text-sm text-amber-600 mt-2 font-medium">
+                  Save your workflow first to get API invocation details
+                </p>
+              ) : (
+                <p className="text-sm text-gray-600 mt-2">
+                  Use this curl command to invoke your workflow via JSON-RPC 2.0
+                </p>
+              )}
+            </div>
+
+            {/* Content */}
+            <div className="px-6 py-4">
+              {!workflowVersionId ? (
+                <div className="text-center py-8">
+                  <div className="bg-amber-50 border border-amber-200 rounded-lg p-6">
+                    <svg
+                      className="w-12 h-12 text-amber-500 mx-auto mb-4"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+                      />
+                    </svg>
+                    <h4 className="text-lg font-semibold text-gray-900 mb-2">Workflow Not Saved</h4>
+                    <p className="text-sm text-gray-600 mb-4">
+                      You need to save your workflow before you can get the API invocation details. Once saved,
+                      you&apos;ll get a workflow version ID that you can use to invoke it via API.
+                    </p>
+                    <Button onClick={() => setIsOpen(false)} variant="default">
+                      Got it
+                    </Button>
+                  </div>
+                </div>
+              ) : (
+                <div className="space-y-4">
+                  {/* Workflow ID Info */}
+                  <div className="bg-blue-50 border border-blue-200 rounded-lg p-3">
+                    <div className="flex items-start gap-2">
+                      <svg
+                        className="w-4 h-4 text-blue-600 mt-0.5"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                        />
+                      </svg>
+                      <div className="text-sm">
+                        <span className="font-medium text-blue-900">Workflow ID: </span>
+                        <code className="text-blue-700 bg-blue-100 px-1.5 py-0.5 rounded font-mono text-xs">
+                          {workflowVersionId}
+                        </code>
+                      </div>
+                    </div>
+                  </div>
+
+                  {/* Curl Command */}
+                  <div className="relative">
+                    <div className="flex items-center justify-between mb-2">
+                      <label className="text-sm font-medium text-gray-700">cURL Command</label>
+                      <Button
+                        onClick={handleCopy}
+                        variant="ghost"
+                        size="sm"
+                        className="h-auto py-1 px-2 text-xs"
+                        data-testid="copy-curl-button"
+                      >
+                        {copied ? (
+                          <>
+                            <Check className="w-3 h-3 mr-1 text-green-600" />
+                            Copied!
+                          </>
+                        ) : (
+                          <>
+                            <Copy className="w-3 h-3 mr-1" />
+                            Copy
+                          </>
+                        )}
+                      </Button>
+                    </div>
+                    <pre className="bg-gray-900 text-gray-100 p-4 rounded-lg overflow-x-auto text-xs font-mono leading-relaxed border border-gray-700">
+                      {curlCommand}
+                    </pre>
+                  </div>
+
+                  {/* Instructions */}
+                  <div className="bg-gray-50 border border-gray-200 rounded-lg p-4">
+                    <h4 className="text-sm font-semibold text-gray-900 mb-2">Setup Instructions</h4>
+                    <ol className="text-sm text-gray-700 space-y-2 list-decimal list-inside">
+                      <li>
+                        Replace <code className="bg-gray-200 px-1.5 py-0.5 rounded text-xs">YOUR_API_KEY</code> with
+                        your actual API key
+                      </li>
+                      <li>
+                        Replace{" "}
+                        <code className="bg-gray-200 px-1.5 py-0.5 rounded text-xs">&quot;Your input here&quot;</code>{" "}
+                        with your workflow input
+                      </li>
+                      <li>
+                        Update the <code className="bg-gray-200 px-1.5 py-0.5 rounded text-xs">goal</code> parameter to
+                        describe your workflow objective
+                      </li>
+                      <li>Run the command in your terminal or integrate it into your application</li>
+                    </ol>
+                  </div>
+                </div>
+              )}
+            </div>
+
+            {/* Footer */}
+            <div className="px-6 py-4 bg-gray-50 border-t border-gray-200 rounded-b-xl">
+              <div className="flex items-center justify-between">
+                <a
+                  href="https://www.jsonrpc.org/specification"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-xs text-blue-600 hover:text-blue-700 hover:underline"
+                >
+                  Learn more about JSON-RPC 2.0 →
+                </a>
+                <Button onClick={() => setIsOpen(false)} variant="default">
+                  Close
+                </Button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/apps/web/src/app/(editor)/edit/components/json-editor/EditorHeader.tsx
+++ b/apps/web/src/app/(editor)/edit/components/json-editor/EditorHeader.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@/components/ui/button"
 import type { Tables } from "@lucky/shared/client"
 import Link from "next/link"
+import WorkflowInvocationButton from "../WorkflowInvocationButton"
 
 type EditorHeaderProps = {
   workflowVersion?: Tables<"WorkflowVersion">
@@ -67,7 +68,9 @@ export default function EditorHeader({
         </div>
 
         <div className="flex items-center gap-3">
-          {workflowVersion && (
+          <WorkflowInvocationButton workflowVersionId={workflowVersion?.wf_version_id} />
+
+          {workflowVersion ? (
             <Link
               href={"/"}
               className="px-4 py-2 bg-gradient-to-r from-green-500 to-emerald-600 text-white rounded-md hover:from-green-600 hover:to-emerald-700 transition-all duration-200 flex items-center gap-2 text-sm font-medium shadow-sm cursor-pointer"
@@ -88,6 +91,24 @@ export default function EditorHeader({
               </svg>
               Run
             </Link>
+          ) : (
+            <Button variant="outline" size="sm" disabled title="Save workflow first to run it">
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z"
+                />
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                />
+              </svg>
+              Run
+            </Button>
           )}
 
           <div className="relative group">

--- a/apps/web/src/components/quick-start/QuickStartCard.tsx
+++ b/apps/web/src/components/quick-start/QuickStartCard.tsx
@@ -2,9 +2,10 @@
 
 import { Button } from "@/components/ui/button"
 import type { WorkflowConfig } from "@lucky/core/workflow/schema/workflow.types"
-import { ArrowRight, CheckCircle2, Sparkles } from "lucide-react"
+import { ArrowRight, Sparkles } from "lucide-react"
 import Link from "next/link"
-import { useState } from "react"
+import { useRouter } from "next/navigation"
+import { useCallback } from "react"
 
 const DEMO_WORKFLOW: WorkflowConfig = {
   nodes: [
@@ -25,56 +26,15 @@ const DEMO_WORKFLOW: WorkflowConfig = {
   },
 }
 
-const DEMO_QUESTION = "What are three benefits of using AI workflows?"
-
 export function QuickStartCard() {
-  const [isRunning, setIsRunning] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-  const [result, setResult] = useState<string | null>(null)
+  const router = useRouter()
 
-  const handleQuickStart = async () => {
-    setIsRunning(true)
-    setError(null)
-    setResult(null)
-
-    try {
-      const response = await fetch("/api/workflow/invoke", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          dslConfig: DEMO_WORKFLOW,
-          evalInput: {
-            workflowId: "quick-start-demo",
-            type: "text",
-            question: DEMO_QUESTION,
-            answer: "",
-            goal: "Demonstrate AI workflow in action",
-          },
-        }),
-      })
-
-      if (!response.ok) {
-        const errorData = await response.json().catch(() => ({ error: "Network error" }))
-        throw new Error(errorData.error || "Failed to run demo")
-      }
-
-      const data = await response.json()
-
-      if (!data.success) {
-        throw new Error(data.error || "Demo failed to complete")
-      }
-
-      setResult(data.data?.finalResponse || "Demo completed successfully!")
-    } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : "Something went wrong. Please try again."
-      setError(errorMessage)
-      console.error("Error running demo:", err)
-    } finally {
-      setIsRunning(false)
-    }
-  }
+  const handleLoadDemo = useCallback(() => {
+    // Store the demo workflow in sessionStorage to load it in the editor
+    sessionStorage.setItem("demo_workflow", JSON.stringify(DEMO_WORKFLOW))
+    // Navigate to the editor
+    router.push("/edit")
+  }, [router])
 
   return (
     <div className="bg-gradient-to-br from-blue-50 to-indigo-50 dark:from-blue-950/20 dark:to-indigo-950/20 rounded-lg p-6 border border-blue-200 dark:border-blue-800">
@@ -85,52 +45,13 @@ export function QuickStartCard() {
         <div className="flex-1">
           <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100 mb-2">Try it in 30 seconds</h3>
           <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
-            See an AI workflow in action. We&apos;ll ask it: &ldquo;{DEMO_QUESTION}&rdquo;
+            Load a demo workflow and see how it works. You can run it yourself when you&apos;re ready.
           </p>
 
-          {result && (
-            <div className="mb-4 p-4 bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded">
-              <div className="flex items-start gap-2 mb-2">
-                <CheckCircle2 className="w-5 h-5 text-green-600 dark:text-green-400 flex-shrink-0 mt-0.5" />
-                <div className="flex-1">
-                  <p className="font-medium text-green-900 dark:text-green-100 text-sm mb-1">Workflow completed!</p>
-                  <p className="text-sm text-green-800 dark:text-green-200">{result}</p>
-                </div>
-              </div>
-              <div className="mt-3 pt-3 border-t border-green-200 dark:border-green-800">
-                <Link
-                  href="/edit"
-                  className="text-sm text-green-700 dark:text-green-300 hover:text-green-900 dark:hover:text-green-100 font-medium inline-flex items-center gap-1"
-                >
-                  Create your own workflow
-                  <ArrowRight className="w-3 h-3" />
-                </Link>
-              </div>
-            </div>
-          )}
-
-          {error && (
-            <div className="mb-4 p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded text-sm text-red-700 dark:text-red-400">
-              <p className="font-medium mb-1">Couldn&apos;t run demo</p>
-              <p className="text-xs">{error}</p>
-            </div>
-          )}
-
-          {!result && (
-            <Button onClick={handleQuickStart} disabled={isRunning} className="group">
-              {isRunning ? (
-                <>
-                  <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin mr-2" />
-                  Running demo...
-                </>
-              ) : (
-                <>
-                  Run demo now
-                  <ArrowRight className="w-4 h-4 ml-2 group-hover:translate-x-1 transition-transform" />
-                </>
-              )}
-            </Button>
-          )}
+          <Button onClick={handleLoadDemo} className="group">
+            Load demo workflow
+            <ArrowRight className="w-4 h-4 ml-2 group-hover:translate-x-1 transition-transform" />
+          </Button>
         </div>
       </div>
     </div>

--- a/apps/web/src/lib/generate-curl-command.ts
+++ b/apps/web/src/lib/generate-curl-command.ts
@@ -1,0 +1,26 @@
+/**
+ * Generate a curl command to invoke a workflow via JSON-RPC 2.0
+ */
+export function generateCurlCommand(workflowVersionId: string, baseUrl?: string): string {
+  const apiUrl = baseUrl || process.env.NEXT_PUBLIC_BASE_URL || "https://your-api.com"
+  const endpoint = `${apiUrl}/api/v1/invoke`
+
+  const curlCommand = `curl -X POST ${endpoint} \\
+  -H "Content-Type: application/json" \\
+  -H "Authorization: Bearer YOUR_API_KEY" \\
+  -d '{
+    "jsonrpc": "2.0",
+    "id": "req_001",
+    "method": "workflow.invoke",
+    "params": {
+      "workflow_id": "${workflowVersionId}",
+      "input": "Your input here",
+      "options": {
+        "goal": "Describe your workflow goal",
+        "trace": true
+      }
+    }
+  }'`
+
+  return curlCommand
+}

--- a/packages/shared/src/types/database.types.ts
+++ b/packages/shared/src/types/database.types.ts
@@ -8,6 +8,57 @@ export type Database = {
   }
   iam: {
     Tables: {
+      org_invites: {
+        Row: {
+          accepted_at: string | null
+          created_at: string
+          email: string
+          expires_at: string
+          invite_id: string
+          invited_by: string | null
+          org_id: string
+          role: Database["iam"]["Enums"]["org_role"]
+          token: string
+        }
+        Insert: {
+          accepted_at?: string | null
+          created_at?: string
+          email: string
+          expires_at: string
+          invite_id?: string
+          invited_by?: string | null
+          org_id: string
+          role?: Database["iam"]["Enums"]["org_role"]
+          token: string
+        }
+        Update: {
+          accepted_at?: string | null
+          created_at?: string
+          email?: string
+          expires_at?: string
+          invite_id?: string
+          invited_by?: string | null
+          org_id?: string
+          role?: Database["iam"]["Enums"]["org_role"]
+          token?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "org_invites_invited_by_fkey"
+            columns: ["invited_by"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["clerk_id"]
+          },
+          {
+            foreignKeyName: "org_invites_org_id_fkey"
+            columns: ["org_id"]
+            isOneToOne: false
+            referencedRelation: "orgs"
+            referencedColumns: ["org_id"]
+          },
+        ]
+      }
       org_memberships: {
         Row: {
           clerk_id: string
@@ -114,6 +165,7 @@ export type Database = {
       }
     }
     Enums: {
+      org_role: "owner" | "admin" | "member"
       user_status: "active" | "disabled" | "invited"
     }
     CompositeTypes: {
@@ -1121,6 +1173,7 @@ export type Constants = typeof _Constants
 const _Constants = {
   iam: {
     Enums: {
+      org_role: ["owner", "admin", "member"],
       user_status: ["active", "disabled", "invited"],
     },
   },


### PR DESCRIPTION
## Summary
- Add WorkflowInvocationButton component with curl command modal for JSON-RPC 2.0 API invocation
- Implement generateCurlCommand utility for creating curl examples with placeholders
- Fix QuickStartCard to load demo workflow into editor without auto-executing
- Make editor header always visible regardless of workflow save state
- Make Invoke button always clickable with contextual messaging when workflow unsaved

## Changes

### New Components
- **WorkflowInvocationButton.tsx**: Modal component showing curl command and invocation instructions
  - Shows curl command when workflow is saved
  - Shows helpful "save first" message when workflow not saved
  - Copy-to-clipboard functionality
  - Responsive design with proper error states

### New Utilities
- **generate-curl-command.ts**: Generates JSON-RPC 2.0 curl commands with placeholder values

### Modified Components
- **EditModeSelector.tsx**: Added logic to load demo workflow from sessionStorage without executing
- **EditorHeader.tsx** (json-editor): Made header always visible with Invoke button
- **QuickStartCard.tsx**: Changed to store workflow in sessionStorage and navigate to editor instead of auto-executing

## Design Decisions
1. **Always-visible header**: Users can see invocation options even before saving
2. **Contextual Invoke button**: Shows different UI based on save state rather than being disabled
3. **sessionStorage for demo**: Clean handoff between pages without persistence
4. **JSON-RPC 2.0 standard**: Following industry-standard RPC protocol

## Test Plan
- [ ] Verify Invoke button appears in both graph and JSON editor modes
- [ ] Click Invoke when workflow is saved - should show curl command
- [ ] Click Invoke when workflow is not saved - should show save-first message
- [ ] Test copy-to-clipboard functionality
- [ ] Click "Run demo now" on homepage - should load into editor WITHOUT executing
- [ ] Verify header remains visible at all times

🤖 Generated with [Claude Code](https://claude.com/claude-code)